### PR TITLE
Make first reading async

### DIFF
--- a/inc/umain_async.inc
+++ b/inc/umain_async.inc
@@ -289,3 +289,101 @@ begin
     Exit;
   Synchronize(@ApplyResult);
 end;
+
+{------------------------------------------------------------------------------
+  TGlucoseFetchThread
+  -------------------
+  Off-main-thread CGM fetch. Owns the synchronous api.getReadings call so the
+  UI stays responsive while the network round-trip is in flight.
+ ------------------------------------------------------------------------------}
+constructor TGlucoseFetchThread.Create(AOwner: TfBG; Boot: boolean;
+Force: boolean);
+begin
+  inherited Create(true);
+  FreeOnTerminate := false;
+  FOwner := AOwner;
+  FBoot := Boot;
+  FForce := Force;
+  FErrorMsg := '';
+  SetLength(FResults, 0);
+  Start;
+end;
+
+procedure TGlucoseFetchThread.Execute;
+{$ifdef DEBUG}
+var
+  diag: string;
+{$endif}
+begin
+  // Worker thread — must not touch LCL/UI. api.getReadings is the synchronous
+  // HTTP call we want to keep off the main thread. The Boot flag triggers
+  // the legacy "two quick attempts" semantics from the old FormCreate path.
+  try
+    try
+      if not Assigned(api) then
+        Exit;
+
+      {$ifdef DEBUG}
+      FResults := api.getReadings(MAX_MIN, MAX_RESULT, '', diag);
+      {$else}
+      FResults := api.getReadings(MAX_MIN, MAX_RESULT);
+      {$endif}
+
+      if FBoot and (Length(FResults) = 0) and (not Terminated) then
+      begin
+        {$ifdef DEBUG}
+        FResults := api.getReadings(MAX_MIN, MAX_RESULT, '', diag);
+        {$else}
+        FResults := api.getReadings(MAX_MIN, MAX_RESULT);
+        {$endif}
+      end;
+
+      if Assigned(api) then
+        FErrorMsg := api.errormsg;
+    except
+      on E: Exception do
+      begin
+        SetLength(FResults, 0);
+        FErrorMsg := E.ClassName + ': ' + E.Message;
+      end;
+    end;
+  finally
+    if not Terminated then
+      Synchronize(@ApplyResult);
+  end;
+end;
+
+procedure TGlucoseFetchThread.ApplyResult;
+var
+  applied: boolean;
+begin
+  if not Assigned(FOwner) then
+    Exit;
+
+  if FOwner.FShuttingDown then
+  begin
+    // Owner is tearing down. Don't touch UI; only clear the in-flight flag
+    // so a future fetch (post-restart) isn't gated.
+    FOwner.FFetchInFlight := false;
+    if FBoot then
+      FOwner.FBootFetchPending := false;
+    Exit;
+  end;
+
+  try
+    applied := FOwner.ApplyFetchedReadings(FResults, FErrorMsg, FBoot);
+    if applied then
+    begin
+      FOwner.ProcessCurrentReading;
+      FOwner.FinalizeReadingUpdate(FBoot);
+    end;
+  finally
+    FOwner.FFetchInFlight := false;
+    if FBoot then
+      FOwner.FBootFetchPending := false;
+    if Assigned(native) then
+      native.updateDone;
+    // The thread reference owned by TfBG will be cleared by the next
+    // RequestAsyncFetch (which creates a fresh instance) or at shutdown.
+  end;
+end;

--- a/inc/umain_glucose.inc
+++ b/inc/umain_glucose.inc
@@ -222,15 +222,13 @@ begin
 end;
 
 function TfBG.updateReading(boot: boolean = false): boolean;
+var
+  force: boolean;
 begin
   {$ifdef DEBUG}
   if debug_load_text then
-  begin
     lVal.Caption := '<Updating>';
-    Application.ProcessMessages;
-  end;
   {$endif}
-  Result := false;
   lAgo.Caption := '⟳' + lAgo.Caption;
 
   native.start;
@@ -239,33 +237,15 @@ begin
   if not tAgo.Enabled then
     lAgo.Caption := '🕑 ' + RS_UNKNOWN_TIME;
 
-  {$ifdef DEBUG}
-  if debug_load_text then
-  begin
-    lVal.Caption := '<Fetching>';
-    Application.ProcessMessages;
-  end;
-  {$endif}
-  if FForceRefresh then
-  begin
-    if not FetchAndValidateReadingsForced then
-      Exit;
+  // The fetch now runs on TGlucoseFetchThread. The post-fetch UI flow
+  // (ApplyFetchedReadings → ProcessCurrentReading → FinalizeReadingUpdate)
+  // is dispatched via Synchronize when the worker completes. Result is the
+  // dispatch status: True = a fetch is starting (or already in flight from
+  // a recent dispatch), False = api unavailable.
+  force := FForceRefresh;
+  if force then
     FForceRefresh := false;
-  end
-  else
-  if not FetchAndValidateReadings then
-    Exit;
-
-  {$ifdef DEBUG}
-  if debug_load_text then
-  begin
-    lVal.Caption := '<Processing>';
-    Application.ProcessMessages;
-  end;
-  {$endif}
-  ProcessCurrentReading;
-
-  Result := FinalizeReadingUpdate(boot);
+  Result := RequestAsyncFetch(boot, force);
 end;
 
 procedure TfBG.FinalizeUpdate;
@@ -797,7 +777,7 @@ var
   {$ifdef DEBUG}
   res: string;
   {$endif}
-  msg: string;
+  fetched: BGResults;
 const
   API_CACHE_SECONDS = 10;
 begin
@@ -824,7 +804,7 @@ begin
   end;
 
   {$ifdef DEBUG}
-  bgs := api.getReadings(MAX_MIN, MAX_RESULT, '', res);
+  fetched := api.getReadings(MAX_MIN, MAX_RESULT, '', res);
   if miDebugBackend.Checked then
     if Showing then
       if res.IsEmpty then
@@ -836,8 +816,40 @@ begin
           IfThen(ForceRefresh, 'Debug Info (Forced)', 'Debug Info'),
           '', res, uxmtCustom, 10);
   {$ELSE}
-  bgs := api.getReadings(MAX_MIN, MAX_RESULT);
+  fetched := api.getReadings(MAX_MIN, MAX_RESULT);
   {$endif}
+
+  Result := ApplyFetchedReadings(fetched, api.errormsg, false);
+end;
+
+{------------------------------------------------------------------------------
+  ApplyFetchedReadings
+  --------------------
+  Main-thread half of a fetch: takes the readings returned by the network call
+  (whether the call happened inline or on a TGlucoseFetchThread worker) and
+  runs all of the side-effecting bookkeeping — cache reconciliation, override
+  settings, warning panel, alert engine, dot placement.
+
+  Returning False here means "no usable data to render"; the caller (sync
+  flow or worker-thread ApplyResult) should skip ProcessCurrentReading /
+  FinalizeReadingUpdate and let the warning panel + periodic timer drive
+  the next attempt.
+ ------------------------------------------------------------------------------}
+function TfBG.ApplyFetchedReadings(const Readings: BGResults;
+const ErrorMsg: string; Boot: boolean): boolean;
+var
+  msg: string;
+begin
+  Result := false;
+
+  // Copy worker output into the main-thread bgs slot.
+  if Length(Readings) > 0 then
+  begin
+    SetLength(bgs, Length(Readings));
+    Move(Readings[0], bgs[0], Length(Readings) * SizeOf(BGReading));
+  end
+  else
+    SetLength(bgs, 0);
 
   FLastAPICall := Now;
 
@@ -854,11 +866,11 @@ begin
     finally
       LeaveCriticalSection(FReadingsLock);
     end;
-    TrndiDLog('DoFetchAndValidateReadings: API returned no data, using cached readings');
-    FLastConnectionDetail := Trim(api.errormsg);
+    TrndiDLog('ApplyFetchedReadings: API returned no data, using cached readings');
+    FLastConnectionDetail := Trim(ErrorMsg);
     if FLastConnectionDetail = '' then
       FLastConnectionDetail := RS_NO_BACKEND;
-    SetConnectionBadge(ClassifyConnectionStatus(api.errormsg), RGBToColor(185, 60, 45));
+    SetConnectionBadge(ClassifyConnectionStatus(ErrorMsg), RGBToColor(185, 60, 45));
     tPing.Enabled := true;
     tPingTimer(nil);
   end
@@ -879,15 +891,18 @@ begin
     SetConnectionBadge(RS_CONN_OK, RGBToColor(60, 150, 90));
   end;
 
-  if native.GetBoolSetting('override.enabled') then
+  if Assigned(api) then
   begin
-    api.cgmLo := native.GetIntSetting('override.lo', api.cgmLo);
-    api.cgmHi := native.GetIntSetting('override.hi', api.cgmHi);
-  end;
-  if native.GetBoolSetting('override.range') then
-  begin
-    api.cgmRangeLo := native.GetIntSetting('override.rangelo', api.cgmRangeLo);
-    api.cgmRangeHi := native.GetIntSetting('override.rangehi', api.cgmRangeHi);
+    if native.GetBoolSetting('override.enabled') then
+    begin
+      api.cgmLo := native.GetIntSetting('override.lo', api.cgmLo);
+      api.cgmHi := native.GetIntSetting('override.hi', api.cgmHi);
+    end;
+    if native.GetBoolSetting('override.range') then
+    begin
+      api.cgmRangeLo := native.GetIntSetting('override.rangelo', api.cgmRangeLo);
+      api.cgmRangeHi := native.GetIntSetting('override.rangehi', api.cgmRangeHi);
+    end;
   end;
 
   hideWarningPanel;
@@ -895,21 +910,21 @@ begin
   if (Length(bgs) < 1) or (not IsDataFresh) then
   begin
     msg := RS_NO_BACKEND;
-    if Assigned(api) and (Trim(api.errormsg) <> '') then
+    if Trim(ErrorMsg) <> '' then
     begin
-      msg := msg + sLineBreak + api.errormsg;
-      TrndiDLog('Backend error: ' + api.errormsg);
+      msg := msg + sLineBreak + ErrorMsg;
+      TrndiDLog('Backend error: ' + ErrorMsg);
     end;
 
     FLastConnectionDetail := msg;
-    SetConnectionBadge(ClassifyConnectionStatus(api.errormsg), RGBToColor(185, 60, 45));
+    SetConnectionBadge(ClassifyConnectionStatus(ErrorMsg), RGBToColor(185, 60, 45));
 
-    if (Length(bgs) > 0) then
-    try
-    except
-    end;
-
-    showWarningPanel(msg, wsCritical, true);
+    // On boot, prefer the dedicated boot-failure message so the user knows
+    // it's the first fetch that failed (and not a mid-session outage).
+    if Boot then
+      showWarningPanel(RS_NO_BOOT_READING, wsCritical, true)
+    else
+      showWarningPanel(msg, wsCritical, true);
 
     if akMissing in FAlertEngine.EvaluateMissing then
       native.attention(RS_ATTENTION_MISSING, RS_ATTENTION_MISSING_DESC);
@@ -918,9 +933,63 @@ begin
 
   FAlertEngine.ResetMissing;
 
-  TrndiDLog(Format('DoFetchAndValidateReadings: Got %d readings from API', [Length(bgs)]));
+  TrndiDLog(Format('ApplyFetchedReadings: Got %d readings', [Length(bgs)]));
 
   PlaceTrendDots(bgs);
+  Result := true;
+end;
+
+{------------------------------------------------------------------------------
+  RequestAsyncFetch
+  -----------------
+  Spawn a TGlucoseFetchThread to call api.getReadings off the main thread.
+  Drops the request if a fetch is already in flight (caller can rely on the
+  in-flight one to complete shortly). On success, the worker's ApplyResult
+  Synchronizes back into ApplyFetchedReadings + ProcessCurrentReading +
+  FinalizeReadingUpdate.
+
+  Boot   — preserves the two-attempt fast retry that used to live in
+           FormCreate's blocking path, and routes the failure to the
+           boot-specific warning panel.
+  Force  — bypasses any caller-side caching; reserved for future use (the
+           worker currently always hits the API).
+ ------------------------------------------------------------------------------}
+function TfBG.RequestAsyncFetch(Boot: boolean; Force: boolean): boolean;
+begin
+  Result := false;
+
+  if FShuttingDown then
+    Exit;
+
+  if api = nil then
+    Exit;
+
+  if FFetchInFlight then
+  begin
+    TrndiDLog('RequestAsyncFetch: dropped — fetch already in flight');
+    // A request is already pending; the in-flight ApplyResult will call
+    // FinalizeReadingUpdate shortly.
+    Result := true;
+    Exit;
+  end;
+
+  // Lazily reap a previously-finished worker before starting a new one;
+  // mirrors the pattern used by FPredictionThread.
+  if Assigned(FGlucoseFetchThread) and FGlucoseFetchThread.Finished then
+  begin
+    FGlucoseFetchThread.WaitFor;
+    FreeAndNil(FGlucoseFetchThread);
+  end;
+
+  FFetchInFlight := true;
+  if Boot then
+    FBootFetchPending := true;
+
+  native.updateBegin;
+  TrndiDLog('RequestAsyncFetch: starting worker (boot=' +
+    BoolToStr(Boot, true) + ' force=' + BoolToStr(Force, true) + ')');
+
+  FGlucoseFetchThread := TGlucoseFetchThread.Create(Self, Boot, Force);
   Result := true;
 end;
 

--- a/inc/umain_glucose.inc
+++ b/inc/umain_glucose.inc
@@ -239,13 +239,15 @@ begin
 
   // The fetch now runs on TGlucoseFetchThread. The post-fetch UI flow
   // (ApplyFetchedReadings → ProcessCurrentReading → FinalizeReadingUpdate)
-  // is dispatched via Synchronize when the worker completes. Result is the
-  // dispatch status: True = a fetch is starting (or already in flight from
-  // a recent dispatch), False = api unavailable.
+  // is dispatched via Synchronize when the worker completes.
+  //
+  // Only consume FForceRefresh once a fresh worker is actually created — if
+  // RequestAsyncFetch drops the request (api unavailable, fetch in flight),
+  // the force intent must survive so the next attempt honours it.
   force := FForceRefresh;
-  if force then
-    FForceRefresh := false;
   Result := RequestAsyncFetch(boot, force);
+  if Result and force then
+    FForceRefresh := false;
 end;
 
 procedure TfBG.FinalizeUpdate;
@@ -967,9 +969,21 @@ begin
   if FFetchInFlight then
   begin
     TrndiDLog('RequestAsyncFetch: dropped — fetch already in flight');
-    // A request is already pending; the in-flight ApplyResult will call
-    // FinalizeReadingUpdate shortly.
-    Result := true;
+    // A request is already pending; return False so the caller knows no new
+    // worker was created and can preserve one-shot state (e.g. FForceRefresh)
+    // for the next attempt.
+    Exit;
+  end;
+
+  // Second guard: ApplyResult clears FFetchInFlight from inside Synchronize,
+  // which returns before the worker's Execute has finished unwinding. In that
+  // brief window FGlucoseFetchThread.Finished is still false even though
+  // FFetchInFlight is false — without this check the assignment below would
+  // overwrite a still-running thread reference and leak it. Drop the request;
+  // the next periodic/menu trigger will pick it up once Finished is true.
+  if Assigned(FGlucoseFetchThread) and (not FGlucoseFetchThread.Finished) then
+  begin
+    TrndiDLog('RequestAsyncFetch: dropped — previous worker still tearing down');
     Exit;
   end;
 

--- a/inc/umain_init.inc
+++ b/inc/umain_init.inc
@@ -913,15 +913,52 @@ begin
     lPredict.Visible := PredictGlucoseReading;
   end;
 
-  // Final initialization and first reading
+  // Final initialization and first reading. The fetch is dispatched to a
+  // background TGlucoseFetchThread so the splash isn't held by the network
+  // round-trip; the worker's ApplyResult runs the post-fetch UI flow once
+  // results land. The legacy "two quick attempts" semantics are now inside
+  // the worker (Execute retries once when boot+empty).
   Application.ProcessMessages;
   fSplash.incProgress(90, RS_INIT_FETCH);
-  if not updateReading(true) then
-  begin
-    fSplash.incProgress(95, RS_INIT_FIRST);
-    updateReading; // Second attempt for setup
-    showWarningPanel(RS_NO_BOOT_READING, wsCritical);
-  end;
+
+  // Neutralize the visual chrome that would otherwise leak through while we
+  // wait. FormPaint also short-circuits range-band drawing while
+  // FBootFetchPending is true so the threshold lines don't appear over a
+  // value we don't have yet.
+  // The form's resize handler autosizes lVal to fill most of the height;
+  // a short single glyph reads as "loading" without being mistaken for a
+  // numeric reading, and won't get rotated/clipped like a sentence would.
+  lVal.Caption := '⟳';
+  lVal.Font.Style := lVal.Font.Style - [fsStrikeOut];
+  lArrow.Caption := '';
+  lDiff.Caption := '';
+  lRef.Caption := '';
+  lAgo.Caption := RS_INIT_FETCH;
+  lTir.Caption := '';
+  if Assigned(pnOffReading) then
+    pnOffReading.Visible := false;
+  if Assigned(pnOffRange) then
+    pnOffRange.Visible := false;
+  if Assigned(pnOffRangeBar) then
+    pnOffRangeBar.Visible := false;
+  if Assigned(pnNextProgress) then
+    pnNextProgress.Visible := false;
+  fBG.Color := clBlack;
+  if Assigned(lPredict) then
+    lPredict.Visible := false;
+
+  // The actual fetch is kicked off via a one-shot timer (tBootFetch) so the
+  // worker thread is created only after Application.Run is pumping the
+  // message loop. Spawning a TThread that immediately blocks on a long Sleep
+  // from inside FormCreate can leave the form's WM_PAINT queued indefinitely
+  // — symptoms include "icon in taskbar but window never draws". Letting the
+  // message loop run first guarantees the form is painted and interactive
+  // before any threading machinery starts.
+  FBootFetchPending := true;
+  tBootFetch := TTimer.Create(Self);
+  tBootFetch.Interval := 50;
+  tBootFetch.OnTimer := @tBootFetchTimer;
+  tBootFetch.Enabled := true;
 
   Chroma := TRazerChromaFactory.CreateInstance;
   if native.GetBoolSetting('razer.enabled', false) then
@@ -940,7 +977,13 @@ begin
   Self.Show;
   Self.BringToFront;
   Self.SetFocus;
-  
+
+  // Flush WM_SHOWWINDOW/WM_PAINT now so the form actually renders before we
+  // hand control to whatever long-running init steps remain. Without this,
+  // a slow worker that calls Synchronize before the message loop is properly
+  // pumping can leave the window in the taskbar but unpainted.
+  Application.ProcessMessages;
+
   tmain.Enabled := true;
   tsetup.Enabled := true;
   

--- a/inc/umain_init.inc
+++ b/inc/umain_init.inc
@@ -954,11 +954,16 @@ begin
   // — symptoms include "icon in taskbar but window never draws". Letting the
   // message loop run first guarantees the form is painted and interactive
   // before any threading machinery starts.
+  //
+  // Note: Enabled stays false here. The explicit Application.ProcessMessages
+  // further down (and any implicit pumping from fSplash.Close / Self.Show)
+  // would otherwise dispatch this 50 ms WM_TIMER while FormCreate is still
+  // mid-setup. Arming happens at the very end of FormCreate.
   FBootFetchPending := true;
   tBootFetch := TTimer.Create(Self);
   tBootFetch.Interval := 50;
   tBootFetch.OnTimer := @tBootFetchTimer;
-  tBootFetch.Enabled := true;
+  tBootFetch.Enabled := false;
 
   Chroma := TRazerChromaFactory.CreateInstance;
   if native.GetBoolSetting('razer.enabled', false) then
@@ -1060,6 +1065,13 @@ begin
   miAdvanced.Insert(miAdvanced.count, miDebugLogAPI);
   miDebugLogAPI.onClick := @miDebugLogAPIClick;
   {$endif}
+
+  // Arm the boot-fetch timer last. From this point there is no further
+  // Application.ProcessMessages in FormCreate, so tBootFetchTimer cannot
+  // fire until FormCreate returns and Application.Run starts pumping —
+  // i.e. the form is fully constructed before any worker thread spawns.
+  if Assigned(tBootFetch) then
+    tBootFetch.Enabled := true;
 end;
 
 // Web Server Methods

--- a/inc/umain_paint.inc
+++ b/inc/umain_paint.inc
@@ -409,10 +409,23 @@ begin
   // value equals the threshold rests flush against the line/band edge.
   rowOffset := (dotHeight div 2) + DOT_OFFSET_RANGE;
 
-  drawLo := (Assigned(api) and (api.cgmLo <> 0) and PaintRange);
-  drawHi := (Assigned(api) and (api.cgmHi <> 0) and PaintRange);
-  drawRangeLo := (Assigned(api) and (api.cgmRangeLo <> 0) and PaintRangeCGMRange);
-  drawRangeHi := (Assigned(api) and (api.cgmRangeHi > 0) and (api.cgmRangeHi < 500) and PaintRangeCGMRange);
+  // Skip threshold/range bands until the first fetch has landed — drawing
+  // them over an empty form (no dot to anchor them against) just produces
+  // the "what is this?" lines visible in the boot screenshot.
+  if FBootFetchPending then
+  begin
+    drawLo := false;
+    drawHi := false;
+    drawRangeLo := false;
+    drawRangeHi := false;
+  end
+  else
+  begin
+    drawLo := (Assigned(api) and (api.cgmLo <> 0) and PaintRange);
+    drawHi := (Assigned(api) and (api.cgmHi <> 0) and PaintRange);
+    drawRangeLo := (Assigned(api) and (api.cgmRangeLo <> 0) and PaintRangeCGMRange);
+    drawRangeHi := (Assigned(api) and (api.cgmRangeHi > 0) and (api.cgmRangeHi < 500) and PaintRangeCGMRange);
+  end;
 
   if drawLo then
     loY := ValueToY(api.cgmLo * BG_CONVERTIONS[mmol][mgdl]) + rowOffset;

--- a/inc/umain_timers.inc
+++ b/inc/umain_timers.inc
@@ -173,6 +173,12 @@ procedure predictFuture(future: integer = 7);
     if not native.GetBoolSetting('predictions.warn') then
       Exit;
 
+    // Skip threshold compare until the first fetch has landed; lastReading
+    // returns a zero-initialized record when bgs is empty and val=0 would
+    // spuriously cross the low threshold.
+    if Length(bgs) = 0 then
+      Exit;
+
     warnLo := math.Max(api.cgmLo, api.limitLO);
     warnHi := math.Min(api.cgmHi, api.limitHI);
 
@@ -765,6 +771,34 @@ procedure TfBG.tSetupTimer(Sender: TObject);
 begin
   tSetup.Enabled := false;
   UpdateUIColors;
+end;
+
+// Fires once shortly after the main form is shown. Performs the synchronous
+// GitHub releases lookup off the FormShow critical path so the form's first
+// paint isn't blocked by network latency.
+procedure TfBG.tUpdateCheckTimer(Sender: TObject);
+begin
+  if Assigned(tUpdateCheck) then
+  begin
+    tUpdateCheck.Enabled := false;
+    FreeAndNil(tUpdateCheck);
+  end;
+  CheckForUpdates;
+end;
+
+// Fires once after Application.Run has started pumping the message loop;
+// kicks off the very first async glucose fetch. Spawning the TThread from
+// inside FormCreate can leave the form's WM_PAINT queued behind a worker
+// that starts its work (Sleep / network I/O) before the main thread has had
+// a chance to enter Application.Run — symptom: form in taskbar, never drawn.
+procedure TfBG.tBootFetchTimer(Sender: TObject);
+begin
+  if Assigned(tBootFetch) then
+  begin
+    tBootFetch.Enabled := false;
+    FreeAndNil(tBootFetch);
+  end;
+  RequestAsyncFetch(true, false);
 end;
 
 procedure TfBG.tSwapTimer(Sender: TObject);

--- a/inc/umain_timers.inc
+++ b/inc/umain_timers.inc
@@ -783,6 +783,12 @@ begin
     tUpdateCheck.Enabled := false;
     FreeAndNil(tUpdateCheck);
   end;
+  // Skip the blocking HTTPS call if the form is tearing down — the
+  // ProcessMessages pumps inside ShutdownBackgroundThreads can otherwise
+  // dispatch this WM_TIMER and stall shutdown on a synchronous network
+  // call.
+  if FShuttingDown then
+    Exit;
   CheckForUpdates;
 end;
 

--- a/units/forms/umain.pp
+++ b/units/forms/umain.pp
@@ -472,6 +472,10 @@ private
                             // Reads/writes happen on the main thread only.
   FBootFetchPending: boolean; // True while the splash-time first fetch is in
                               // flight; gates the boot-failure warning panel.
+  FFetchThreadDetached: boolean; // Set when shutdown gave up waiting on the
+                                 // fetch worker and detached it; gates the
+                                 // api/native free in FormDestroy so the
+                                 // still-running worker doesn't UAF.
   tUpdateCheck: TTimer;       // One-shot deferred CheckForUpdates trigger so
                               // the synchronous HTTPS call doesn't block the
                               // form's first WM_PAINT.
@@ -1040,16 +1044,25 @@ begin
   if assigned(chroma) then
     chroma.free;
 
-  // These should already be freed in FormClose, but check just to be safe
-  if assigned(native) then
+  // These should already be freed in FormClose, but check just to be safe.
+  // If ShutdownBackgroundThreads detached a still-running fetch worker,
+  // leak api/native deliberately: the worker is still inside
+  // api.getReadings on those objects, and freeing them here would crash on
+  // its continuation. The process is exiting; the OS reclaims the memory.
+  if FFetchThreadDetached then
+    TrndiDLog('FormDestroy: skipping api/native free — detached fetch worker still using them')
+  else
   begin
-    native.Free;
-    native := nil;
-  end;
-  if assigned(api) then
-  begin
-    api.Free;
-    api := nil;
+    if assigned(native) then
+    begin
+      native.Free;
+      native := nil;
+    end;
+    if assigned(api) then
+    begin
+      api.Free;
+      api := nil;
+    end;
   end;
 
   // Note: TTrndiExtEngine.ReleaseInstance is already called in FormClose
@@ -1294,7 +1307,25 @@ begin
 end;
 
 procedure TfBG.ShutdownBackgroundThreads;
+const
+  // Budget for waiting on the fetch worker before detaching. Network calls
+  // can outlive this; on timeout we hand the thread off to the runtime and
+  // let it expire on its own (or get killed by process termination).
+  FETCH_SHUTDOWN_TIMEOUT_MS = 3000;
+var
+  deadline: TDateTime;
 begin
+  // Disable and free the deferred GitHub releases check first. Its handler
+  // does a synchronous HTTPS call that would block the ProcessMessages pumps
+  // below if a queued WM_TIMER fires mid-teardown. Clearing the scheduled
+  // flag matches the create-once gate in FormShow.
+  if Assigned(tUpdateCheck) then
+  begin
+    tUpdateCheck.Enabled := false;
+    FreeAndNil(tUpdateCheck);
+  end;
+  FUpdateCheckScheduled := false;
+
   if Assigned(FConnectivityThread) then
   begin
     FConnectivityThread.Terminate;
@@ -1324,11 +1355,32 @@ begin
 
   if Assigned(FGlucoseFetchThread) then
   begin
+    // Terminate only sets a flag; the worker is typically blocked inside the
+    // synchronous api.getReadings call which can't be interrupted from here.
+    // Real cancellation would require an HTTP abort hook in every TrndiAPI
+    // backend (deferred). For now, bound the wait so a slow/dead backend
+    // doesn't hang shutdown; on timeout, detach the worker and let it finish
+    // its network call in the background. FFetchThreadDetached then gates
+    // the api/native free in FormDestroy below to avoid use-after-free.
     FGlucoseFetchThread.Terminate;
-    while not FGlucoseFetchThread.Finished do
+    deadline := IncMilliSecond(Now, FETCH_SHUTDOWN_TIMEOUT_MS);
+    while (not FGlucoseFetchThread.Finished) and (Now < deadline) do
+    begin
       Application.ProcessMessages;
-    FGlucoseFetchThread.WaitFor;
-    FreeAndNil(FGlucoseFetchThread);
+      Sleep(20);
+    end;
+    if FGlucoseFetchThread.Finished then
+    begin
+      FGlucoseFetchThread.WaitFor;
+      FreeAndNil(FGlucoseFetchThread);
+    end
+    else
+    begin
+      TrndiDLog('ShutdownBackgroundThreads: fetch worker still in api.getReadings after timeout; detaching');
+      FGlucoseFetchThread.FreeOnTerminate := true;
+      FGlucoseFetchThread := nil;
+      FFetchThreadDetached := true;
+    end;
   end;
 end;
 

--- a/units/forms/umain.pp
+++ b/units/forms/umain.pp
@@ -131,6 +131,34 @@ protected
 public
   constructor Create(AOwner: TfBG; NumPredictions: integer);
 end;
+
+{**
+  Background fetch of CGM readings. Moves the synchronous @code(api.getReadings)
+  call off the main thread so the UI (splash on boot, form on refresh) stays
+  responsive while the network round-trip is in flight.
+
+  @code(Boot=True) preserves the legacy "two quick attempts" semantics that
+  used to live in @code(FormCreate): if the first fetch returns empty, the
+  thread retries once immediately before reporting failure.
+
+  When @code(Execute) finishes, @code(ApplyResult) is dispatched to the main
+  thread to copy the readings into @code(bgs) and run the existing post-fetch
+  UI sequence (@code(ApplyFetchedReadings), @code(ProcessCurrentReading),
+  @code(FinalizeReadingUpdate)).
+}
+TGlucoseFetchThread = class(TThread)
+private
+  FOwner: TfBG;
+  FBoot: boolean;
+  FForce: boolean;
+  FResults: BGResults;
+  FErrorMsg: string;
+  procedure ApplyResult;
+protected
+  procedure Execute; override;
+public
+  constructor Create(AOwner: TfBG; Boot: boolean; Force: boolean);
+end;
 TDotControl = TPaintBox;
   // Severity of an active warning. Drives panel layout, colors, and opacity.
   // wsInfo:     soft prediction (look-ahead, > 3 min)        — slim amber banner
@@ -439,6 +467,18 @@ private
   FConnectivityThread: TConnectivityCheckThread;
   FPingThread: TConnectivityCheckThread;
   FPredictionThread: TPredictionThread;
+  FGlucoseFetchThread: TGlucoseFetchThread;
+  FFetchInFlight: boolean;  // True while a TGlucoseFetchThread is running.
+                            // Reads/writes happen on the main thread only.
+  FBootFetchPending: boolean; // True while the splash-time first fetch is in
+                              // flight; gates the boot-failure warning panel.
+  tUpdateCheck: TTimer;       // One-shot deferred CheckForUpdates trigger so
+                              // the synchronous HTTPS call doesn't block the
+                              // form's first WM_PAINT.
+  FUpdateCheckScheduled: boolean;
+  tBootFetch: TTimer;         // One-shot trigger for the first async fetch;
+                              // fires only after Application.Run is pumping
+                              // the message loop so the form has painted.
   FInternetBadgeBg: TShape;
   FInternetBadgeShadow: TShape;
   FWarningDots: array of TDotControl;
@@ -465,6 +505,8 @@ private
   Chroma: TRazerChromaBase;
   FAlertEngine: TAlertEngine;
   procedure PersistAlertState(Sender: TObject);
+  procedure tUpdateCheckTimer(Sender: TObject);
+  procedure tBootFetchTimer(Sender: TObject);
 
   function dotsInView: integer;
   function setColorMode: boolean;
@@ -523,6 +565,18 @@ private
       @returns(True on successful fetch/validation.)
    }
   function DoFetchAndValidateReadings(const ForceRefresh: boolean): boolean;
+
+    {** Kick off an asynchronous fetch. The actual network call runs on a
+        background @link(TGlucoseFetchThread) and the result is applied via
+        @link(ApplyFetchedReadings) on the main thread. If a fetch is
+        already in flight the request is dropped (returns @false). }
+  function RequestAsyncFetch(Boot: boolean; Force: boolean): boolean;
+    {** Apply a set of readings returned by the worker thread. Performs all
+        of the post-fetch UI work (cache copy, overrides, warning panel,
+        alert engine, dots). Runs only on the main thread. Returns @true
+        when fresh data was placed in @code(bgs). }
+  function ApplyFetchedReadings(const Readings: BGResults;
+    const ErrorMsg: string; Boot: boolean): boolean;
     // Common implementation
   {** Process the current reading and update any internal state derived from it
       (e.g., predicted values, cached metadata). This is a small helper used
@@ -1267,6 +1321,15 @@ begin
     FPredictionThread.WaitFor;
     FreeAndNil(FPredictionThread);
   end;
+
+  if Assigned(FGlucoseFetchThread) then
+  begin
+    FGlucoseFetchThread.Terminate;
+    while not FGlucoseFetchThread.Finished do
+      Application.ProcessMessages;
+    FGlucoseFetchThread.WaitFor;
+    FreeAndNil(FGlucoseFetchThread);
+  end;
 end;
 
 procedure TfBG.fbReadingsDblClick(Sender: TObject);
@@ -1419,8 +1482,20 @@ begin
     Exit;
   end;
   
-  // Check for updates on startup (non-blocking)
-  CheckForUpdates;
+  // Defer the GitHub releases check off the FormShow path. TrndiNative.getURL
+  // is a synchronous HTTPS call (typ. hundreds of ms, much longer if the
+  // remote stalls). Running it inline blocks the form's first WM_PAINT,
+  // which on slow networks shows up as "icon in taskbar but window invisible"
+  // for the duration of the request. A one-shot TTimer reuses the existing
+  // pattern for tWebServerStart below; the OnTimer handler frees itself.
+  if not FUpdateCheckScheduled then
+  begin
+    FUpdateCheckScheduled := true;
+    tUpdateCheck := TTimer.Create(Self);
+    tUpdateCheck.Interval := 1500;
+    tUpdateCheck.OnTimer := @tUpdateCheckTimer;
+    tUpdateCheck.Enabled := true;
+  end;
 end;
 {$ifdef DARWIN}
 procedure TfBG.ToggleFullscreenMac;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Glucose readings now fetch asynchronously in the background, eliminating UI freezing during startup and data refresh cycles.
  * Visual loading states display while data loads.
  * Improved error messaging for connectivity issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->