### PR TITLE
Make all BG fetch calls async

### DIFF
--- a/inc/umain_async.inc
+++ b/inc/umain_async.inc
@@ -310,10 +310,6 @@ begin
 end;
 
 procedure TGlucoseFetchThread.Execute;
-{$ifdef DEBUG}
-var
-  diag: string;
-{$endif}
 begin
   // Worker thread — must not touch LCL/UI. api.getReadings is the synchronous
   // HTTP call we want to keep off the main thread. The Boot flag triggers
@@ -324,7 +320,7 @@ begin
         Exit;
 
       {$ifdef DEBUG}
-      FResults := api.getReadings(MAX_MIN, MAX_RESULT, '', diag);
+      FResults := api.getReadings(MAX_MIN, MAX_RESULT, '', FDiag);
       {$else}
       FResults := api.getReadings(MAX_MIN, MAX_RESULT);
       {$endif}
@@ -332,7 +328,7 @@ begin
       if FBoot and (Length(FResults) = 0) and (not Terminated) then
       begin
         {$ifdef DEBUG}
-        FResults := api.getReadings(MAX_MIN, MAX_RESULT, '', diag);
+        FResults := api.getReadings(MAX_MIN, MAX_RESULT, '', FDiag);
         {$else}
         FResults := api.getReadings(MAX_MIN, MAX_RESULT);
         {$endif}
@@ -371,6 +367,19 @@ begin
   end;
 
   try
+    {$ifdef DEBUG}
+    if Assigned(FOwner.miDebugBackend) and FOwner.miDebugBackend.Checked and FOwner.Showing then
+    begin
+      if FDiag.IsEmpty then
+        slicke.ux.alert.ExtLog(uxdAuto,
+          IfThen(FForce, 'Debug Info (Forced)', 'Debug Info'),
+          '[empty!]', FDiag)
+      else
+        slicke.ux.alert.ExtLog(uxdAuto,
+          IfThen(FForce, 'Debug Info (Forced)', 'Debug Info'),
+          '', FDiag, uxmtCustom, 10);
+    end;
+    {$endif}
     applied := FOwner.ApplyFetchedReadings(FResults, FErrorMsg, FBoot);
     if applied then
     begin
@@ -385,5 +394,116 @@ begin
       native.updateDone;
     // The thread reference owned by TfBG will be cleared by the next
     // RequestAsyncFetch (which creates a fresh instance) or at shutdown.
+  end;
+end;
+
+{------------------------------------------------------------------------------
+  THistoryFetchThread
+  -------------------
+  Off-main-thread CGM fetch for the history graph. Same shape as
+  TGlucoseFetchThread but the window (minutes, max readings) is supplied per
+  call and the result feeds ShowHistoryGraph on the main thread rather than
+  the live UI's bgs slot.
+ ------------------------------------------------------------------------------}
+constructor THistoryFetchThread.Create(AOwner: TfBG; Minutes, MaxReadings: integer;
+Mode: THistoryFetchMode);
+begin
+  inherited Create(true);
+  FreeOnTerminate := false;
+  FOwner := AOwner;
+  FMinutes := Minutes;
+  FMaxReadings := MaxReadings;
+  FMode := Mode;
+  FErrorMsg := '';
+  SetLength(FResults, 0);
+  Start;
+end;
+
+procedure THistoryFetchThread.Execute;
+var
+  diag: string;
+begin
+  // Worker thread — must not touch LCL/UI. The synchronous api.getReadings
+  // call is the only thing here.
+  try
+    try
+      if not Assigned(api) then
+        Exit;
+
+      FResults := api.getReadings(FMinutes, FMaxReadings, '', diag);
+
+      if Assigned(api) then
+        FErrorMsg := api.errormsg;
+      if (FErrorMsg = '') and (diag <> '') then
+        FErrorMsg := diag;
+    except
+      on E: Exception do
+      begin
+        SetLength(FResults, 0);
+        FErrorMsg := E.ClassName + ': ' + E.Message;
+      end;
+    end;
+  finally
+    if not Terminated then
+      Synchronize(@ApplyResult);
+  end;
+end;
+
+procedure THistoryFetchThread.ApplyResult;
+var
+  cgmHi, cgmLo, cgmRangeHi, cgmRangeLo: integer;
+begin
+  if not Assigned(FOwner) then
+    Exit;
+
+  if FOwner.FShuttingDown then
+  begin
+    // Owner is tearing down — drop everything, just clear the flag so a
+    // hypothetical post-restart fetch isn't gated.
+    FOwner.FHistoryFetchInFlight := false;
+    Exit;
+  end;
+
+  try
+    if Length(FResults) = 0 then
+    begin
+      case FMode of
+      hfm24h:
+        if FErrorMsg <> '' then
+          ShowMessage('No readings returned: ' + FErrorMsg)
+        else
+          ShowMessage('No readings returned for the last 24 hours.');
+      hfmDatePicker:
+        if FErrorMsg <> '' then
+          ShowMessage(Format(RS_DATE_PICKER_NO_READINGS_ERR, [FErrorMsg]))
+        else
+          ShowMessage(RS_DATE_PICKER_NO_READINGS);
+      end;
+      Exit;
+    end;
+
+    if Assigned(api) then
+    begin
+      cgmHi := api.cgmHi;
+      cgmLo := api.cgmLo;
+      cgmRangeHi := api.cgmRangeHi;
+      cgmRangeLo := api.cgmRangeLo;
+    end
+    else
+    begin
+      cgmHi := 180; cgmLo := 60; cgmRangeHi := 160; cgmRangeLo := 80;
+    end;
+
+    ShowHistoryGraph(FResults, un, CurrentHistoryGraphPalette,
+      cgmHi, cgmLo, cgmRangeHi, cgmRangeLo);
+    FOwner.AutoEnableBasalOverlay;
+    if FMode = hfm24h then
+      FOwner.AutoAddPredictionOverlay;
+  finally
+    FOwner.FHistoryFetchInFlight := false;
+    if Assigned(FOwner.mi24h) then
+      FOwner.mi24h.Enabled := true;
+    if Assigned(FOwner.miReadingsSince) then
+      FOwner.miReadingsSince.Enabled := true;
   end;
 end;

--- a/inc/umain_glucose.inc
+++ b/inc/umain_glucose.inc
@@ -512,14 +512,6 @@ begin
   end;
 end;
 
-procedure TfBG.CompleteUIUpdate;
-begin
-  ProcessCurrentReading;
-  UpdateUIBasedOnGlucose;
-  FinalizeUpdate;
-  CalcRangeTime;
-end;
-
 procedure TfBG.FinalizeUIUpdate;
 begin
   UpdateUIBasedOnGlucose;
@@ -774,56 +766,6 @@ begin
   UpdateOffRangePanel(reading.val);
 end;
 
-function TfBG.DoFetchAndValidateReadings(const ForceRefresh: boolean): boolean;
-var
-  {$ifdef DEBUG}
-  res: string;
-  {$endif}
-  fetched: BGResults;
-const
-  API_CACHE_SECONDS = 10;
-begin
-  Result := false;
-
-  if api = nil then
-    Exit;
-
-  if (not ForceRefresh) and (SecondsBetween(Now, FLastAPICall) < API_CACHE_SECONDS) and
-    FCachedReadingsValid then
-  begin
-    EnterCriticalSection(FReadingsLock);
-    try
-      if FCachedReadingsValid and (Length(FCachedReadings) > 0) then
-      begin
-        SetLength(bgs, Length(FCachedReadings));
-        Move(FCachedReadings[0], bgs[0], Length(FCachedReadings) * SizeOf(BGReading));
-        Result := true;
-        Exit;
-      end;
-    finally
-      LeaveCriticalSection(FReadingsLock);
-    end;
-  end;
-
-  {$ifdef DEBUG}
-  fetched := api.getReadings(MAX_MIN, MAX_RESULT, '', res);
-  if miDebugBackend.Checked then
-    if Showing then
-      if res.IsEmpty then
-        slicke.ux.alert.ExtLog(uxdAuto,
-          IfThen(ForceRefresh, 'Debug Info (Forced)', 'Debug Info'),
-          '[empty!]', res)
-      else
-        slicke.ux.alert.ExtLog(uxdAuto,
-          IfThen(ForceRefresh, 'Debug Info (Forced)', 'Debug Info'),
-          '', res, uxmtCustom, 10);
-  {$ELSE}
-  fetched := api.getReadings(MAX_MIN, MAX_RESULT);
-  {$endif}
-
-  Result := ApplyFetchedReadings(fetched, api.errormsg, false);
-end;
-
 {------------------------------------------------------------------------------
   ApplyFetchedReadings
   --------------------
@@ -1007,26 +949,58 @@ begin
   Result := true;
 end;
 
-function TfBG.FetchAndValidateReadings: boolean;
+{------------------------------------------------------------------------------
+  RequestHistoryFetch
+  -------------------
+  Spawn a THistoryFetchThread for a custom-window history-graph fetch. The
+  network call runs off-main and ShowHistoryGraph is opened from the worker's
+  ApplyResult via Synchronize. While in flight, both history menu items are
+  disabled so a second click can't queue a duplicate.
+ ------------------------------------------------------------------------------}
+function TfBG.RequestHistoryFetch(Minutes, MaxReadings: integer;
+Mode: THistoryFetchMode): boolean;
 begin
-  TrndiDLog('umain: About to call native.updateBegin');
-  native.updateBegin;
-  try
-    Result := DoFetchAndValidateReadings(false);
-  finally
-    native.updateDone;
-  end;
-end;
+  Result := false;
 
-function TfBG.FetchAndValidateReadingsForced: boolean;
-begin
-  TrndiDLog('umain: About to call native.updateBegin (force)');
-  native.updateBegin;
-  try
-    Result := DoFetchAndValidateReadings(true);
-  finally
-    native.updateDone;
+  if FShuttingDown then
+    Exit;
+
+  if api = nil then
+  begin
+    ShowMessage('API not initialized yet.');
+    Exit;
   end;
+
+  if FHistoryFetchInFlight then
+  begin
+    TrndiDLog('RequestHistoryFetch: dropped — history fetch already in flight');
+    Exit;
+  end;
+
+  // Mirror RequestAsyncFetch's "previous worker still tearing down" guard.
+  if Assigned(FHistoryFetchThread) and (not FHistoryFetchThread.Finished) then
+  begin
+    TrndiDLog('RequestHistoryFetch: dropped — previous worker still tearing down');
+    Exit;
+  end;
+
+  if Assigned(FHistoryFetchThread) and FHistoryFetchThread.Finished then
+  begin
+    FHistoryFetchThread.WaitFor;
+    FreeAndNil(FHistoryFetchThread);
+  end;
+
+  FHistoryFetchInFlight := true;
+  if Assigned(mi24h) then
+    mi24h.Enabled := false;
+  if Assigned(miReadingsSince) then
+    miReadingsSince.Enabled := false;
+
+  TrndiDLog(Format('RequestHistoryFetch: starting worker (minutes=%d, max=%d, mode=%d)',
+    [Minutes, MaxReadings, Ord(Mode)]));
+
+  FHistoryFetchThread := THistoryFetchThread.Create(Self, Minutes, MaxReadings, Mode);
+  Result := true;
 end;
 
 procedure TfBG.UpdateOffRangePanel(const Value: double);

--- a/inc/umain_menu.inc
+++ b/inc/umain_menu.inc
@@ -224,8 +224,6 @@ var
   minDate, selectedDate: TDateTime;
   mr: TModalResult;
   minutesSince, maxReadings: integer;
-  readings: BGResults;
-  res: string;
   maxAge, maxDays: integer;
   description: string;
 begin
@@ -259,20 +257,7 @@ begin
   begin
     minutesSince := MinutesBetween(Now, selectedDate);
     maxReadings := minutesSince div 5;
-    readings := api.getReadings(minutesSince, maxReadings, '', res);
-
-    if Length(readings) = 0 then
-    begin
-      if res <> '' then
-        ShowMessage(Format(RS_DATE_PICKER_NO_READINGS_ERR, [res]))
-      else
-        ShowMessage(RS_DATE_PICKER_NO_READINGS);
-      Exit;
-    end;
-
-    ShowHistoryGraph(readings, un, CurrentHistoryGraphPalette,
-      api.cgmHi, api.cgmLo, api.cgmRangeHi, api.cgmRangeLo);
-    AutoEnableBasalOverlay;
+    RequestHistoryFetch(minutesSince, maxReadings, hfmDatePicker);
   end;
 end;
 
@@ -476,31 +461,8 @@ begin
 end;
 
 procedure TfBG.mi24hClick(Sender: TObject);
-var
-  res: string;
-  readings: BGResults;
 begin
-  if api = nil then
-  begin
-    ShowMessage('API not initialized yet.');
-    Exit;
-  end;
-
-  readings := api.getReadings(1440, 288, '', res);
-
-  if Length(readings) = 0 then
-  begin
-    if res <> '' then
-      ShowMessage('No readings returned: ' + res)
-    else
-      ShowMessage('No readings returned for the last 24 hours.');
-    Exit;
-  end;
-
-  ShowHistoryGraph(readings, un, CurrentHistoryGraphPalette,
-    api.cgmHi, api.cgmLo, api.cgmRangeHi, api.cgmRangeLo);
-  AutoEnableBasalOverlay;
-  AutoAddPredictionOverlay;
+  RequestHistoryFetch(1440, 288, hfm24h);
 end;
 
 procedure TfBG.miHistoryClick(Sender: TObject);
@@ -541,8 +503,10 @@ begin
       uxmtInformation);
 
     if Result = mrRetry then
-      if FetchAndValidateReadingsForced then
-        CompleteUIUpdate;
+    begin
+      FForceRefresh := true;
+      updateReading;
+    end;
   end
   else
     updateReading;

--- a/units/forms/umain.pp
+++ b/units/forms/umain.pp
@@ -153,11 +153,42 @@ private
   FForce: boolean;
   FResults: BGResults;
   FErrorMsg: string;
+  {$ifdef DEBUG}
+  FDiag: string;
+  {$endif}
   procedure ApplyResult;
 protected
   procedure Execute; override;
 public
   constructor Create(AOwner: TfBG; Boot: boolean; Force: boolean);
+end;
+
+{**
+  Which menu opened the history-graph fetch. Drives the empty-data messages
+  and whether the prediction overlay is auto-added once the graph is shown.
+}
+THistoryFetchMode = (hfm24h, hfmDatePicker);
+
+{**
+  Background fetch of a custom-window glucose history for the history graph.
+  Mirrors TGlucoseFetchThread but takes its window (minutes, max readings)
+  by value and feeds @code(ShowHistoryGraph) on the main thread instead of
+  the live UI's @code(bgs) slot.
+}
+THistoryFetchThread = class(TThread)
+private
+  FOwner: TfBG;
+  FMinutes: integer;
+  FMaxReadings: integer;
+  FMode: THistoryFetchMode;
+  FResults: BGResults;
+  FErrorMsg: string;
+  procedure ApplyResult;
+protected
+  procedure Execute; override;
+public
+  constructor Create(AOwner: TfBG; Minutes, MaxReadings: integer;
+    Mode: THistoryFetchMode);
 end;
 TDotControl = TPaintBox;
   // Severity of an active warning. Drives panel layout, colors, and opacity.
@@ -472,6 +503,11 @@ private
                             // Reads/writes happen on the main thread only.
   FBootFetchPending: boolean; // True while the splash-time first fetch is in
                               // flight; gates the boot-failure warning panel.
+  FHistoryFetchThread: THistoryFetchThread;
+  FHistoryFetchInFlight: boolean; // True while a THistoryFetchThread is
+                                  // running. Reads/writes on the main
+                                  // thread only; gates the menu items so a
+                                  // second click can't queue a duplicate.
   FFetchThreadDetached: boolean; // Set when shutdown gave up waiting on the
                                  // fetch worker and detached it; gates the
                                  // api/native free in FormDestroy so the
@@ -558,23 +594,17 @@ private
   procedure CreateTrendDots;
   procedure placeForm;
 
-    // Helper methods for update procedure
-  {** Fetch readings from the configured data source(s) and validate them.
-      The resulting values are stored in `FCachedReadings` on success.
-      @returns(True if a valid dataset was retrieved.)
-   }
-  function FetchAndValidateReadings: boolean;
-  {** Under-the-hood implementation of FetchAndValidateReadings.
-      @param(ForceRefresh  Force bypass of any caching.)
-      @returns(True on successful fetch/validation.)
-   }
-  function DoFetchAndValidateReadings(const ForceRefresh: boolean): boolean;
-
     {** Kick off an asynchronous fetch. The actual network call runs on a
         background @link(TGlucoseFetchThread) and the result is applied via
         @link(ApplyFetchedReadings) on the main thread. If a fetch is
         already in flight the request is dropped (returns @false). }
   function RequestAsyncFetch(Boot: boolean; Force: boolean): boolean;
+    {** Kick off an asynchronous history-graph fetch on a
+        @link(THistoryFetchThread). Disables the history menu items while
+        the worker is in flight; re-enables them from ApplyResult. Returns
+        @false if a request was already pending or the API isn't ready. }
+  function RequestHistoryFetch(Minutes, MaxReadings: integer;
+    Mode: THistoryFetchMode): boolean;
     {** Apply a set of readings returned by the worker thread. Performs all
         of the post-fetch UI work (cache copy, overrides, warning panel,
         alert engine, dots). Runs only on the main thread. Returns @true
@@ -599,9 +629,6 @@ private
       color/label updates depending on thresholds and state.
    }
   procedure UpdateUIBasedOnGlucose;
-  {** Perform deferred work required after the main UI update chain has finished.
-   }
-  procedure CompleteUIUpdate;
   {** Final housekeeping after the UI update pipeline completes. Ensures that
       timers, overlays and other stateful UI pieces are synchronized after
       a new reading or manual refresh.
@@ -726,8 +753,6 @@ private
    }
   procedure CacheUIState(const UIColor: TColor; const UICaption: string;
     const UITir: string; const UITirColor: TColor);
-  function FetchAndValidateReadingsForced: boolean;
-    // Force fresh API call bypassing cache
 
   procedure HandleLatestReadingFreshness(const LatestReading: BGReading;
     CurrentTime: TDateTime);
@@ -1379,6 +1404,33 @@ begin
       TrndiDLog('ShutdownBackgroundThreads: fetch worker still in api.getReadings after timeout; detaching');
       FGlucoseFetchThread.FreeOnTerminate := true;
       FGlucoseFetchThread := nil;
+      FFetchThreadDetached := true;
+    end;
+  end;
+
+  if Assigned(FHistoryFetchThread) then
+  begin
+    // Same shape as FGlucoseFetchThread: history fetches sit inside the same
+    // uninterruptible api.getReadings call, so bound the wait and detach on
+    // timeout. A detached history worker still touches api when it returns,
+    // so it gates FFetchThreadDetached too (same api/native lifetime).
+    FHistoryFetchThread.Terminate;
+    deadline := IncMilliSecond(Now, FETCH_SHUTDOWN_TIMEOUT_MS);
+    while (not FHistoryFetchThread.Finished) and (Now < deadline) do
+    begin
+      Application.ProcessMessages;
+      Sleep(20);
+    end;
+    if FHistoryFetchThread.Finished then
+    begin
+      FHistoryFetchThread.WaitFor;
+      FreeAndNil(FHistoryFetchThread);
+    end
+    else
+    begin
+      TrndiDLog('ShutdownBackgroundThreads: history worker still in api.getReadings after timeout; detaching');
+      FHistoryFetchThread.FreeOnTerminate := true;
+      FHistoryFetchThread := nil;
       FFetchThreadDetached := true;
     end;
   end;

--- a/units/trndi/ext/trndi.ext.jsfuncs.pp
+++ b/units/trndi/ext/trndi.ext.jsfuncs.pp
@@ -109,27 +109,18 @@ begin
     str, uxmtSquare);
 end;
 
-// Blood Glucose dump, from JS
+// Blood Glucose dump, from JS.
+// Not yet implemented. The previous body issued a synchronous getReadings
+// call on the main thread and discarded the result, which blocked the UI
+// during the HTTP round-trip without returning anything to JS. A proper
+// implementation needs a deferred-resolve path in the JS engine so the
+// fetch can run on a TGlucoseFetchThread-style worker and resolve the
+// promise from ApplyResult.
 function TJSFuncs.bgDump(ctx: pointer; const func: string;
   const params: JSParameters; out res: JSValueVal): boolean;
-var
-  i: integer;
-  r: BGResults;
 begin
-
-  if params[1]^.Data.match <> JD_INT then
-  begin
-    ShowMsg('Unknown paramter #1');
-    Exit(False);
-  end;
-  if params[2]^.Data.match <> JD_INT then
-  begin
-    ShowMsg('Unknown paramter #2');
-    Exit(False);
-  end;
-  tapi.getReadings(params[0]^.Data.Int32Val, params[1]^.Data.Int32Val);
-  //@fixme not done
-  Result := True;
+  ShowMsg('bgDump is not yet implemented');
+  Result := False;
 end;
 
 // backend for asyncGet in JS


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added asynchronous background fetching for glucose history graphs
  * Support for multiple history modes (24-hour and date picker views)

* **Bug Fixes**
  * Improved prevention of duplicate fetch requests while operations are in-flight
  * Enhanced shutdown handling for background workers

* **Refactor**
  * Replaced synchronous fetch operations with an async pipeline for improved responsiveness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->