### PR TITLE
Fix/dexcom diff

### DIFF
--- a/Trndi.lpi
+++ b/Trndi.lpi
@@ -90,6 +90,7 @@
       <UseVersionInfo Value="True"/>
       <AutoIncrementBuild Value="True"/>
       <MajorVersionNr Value="10"/>
+      <MinorVersionNr Value="1"/>
       <BuildNr Value="126"/>
       <StringTable CompanyName="Slicke" FileDescription="Trndi - CGM trend monitor" LegalCopyright="Björn Lindh" ProductName="Trndi"/>
     </VersionInfo>

--- a/inc/umain_glucose.inc
+++ b/inc/umain_glucose.inc
@@ -1323,7 +1323,7 @@ procedure TfBG.ProcessTimeIntervals(const SortedReadings: array of BGReading;
 CurrentTime: TDateTime);
 var
   slotIndex, i, labelNumber, searchStart: integer;
-  slotStart, slotEnd, anchorTime: TDateTime;
+  slotStart, slotEnd, anchorTime, anchorSource: TDateTime;
   slotEpsilon: double;
   found: boolean;
   reading: BGReading;
@@ -1337,10 +1337,25 @@ begin
 
   searchStart := 0;
 
-  anchorTime := RecodeMinute(CurrentTime,
-    (MinuteOf(CurrentTime) div INTERVAL_MINUTES) * INTERVAL_MINUTES);
+  // Anchor from whichever is later: Now or the latest reading's timestamp.
+  // Rounding Now alone would put the anchor before a reading that arrived a
+  // couple of minutes past the last 5-minute boundary (common with Dexcom's
+  // sample cadence + fetch delay), which then skips it from slot 0 and shifts
+  // every subsequent dot one slot to the right, leaving a visible gap.
+  anchorSource := CurrentTime;
+  if SortedReadings[0].date > anchorSource then
+    anchorSource := SortedReadings[0].date;
+
+  anchorTime := RecodeMinute(anchorSource,
+    (MinuteOf(anchorSource) div INTERVAL_MINUTES) * INTERVAL_MINUTES);
   anchorTime := RecodeSecond(anchorTime, 0);
   anchorTime := RecodeMilliSecond(anchorTime, 0);
+
+  // If the latest reading still sits past the anchor+grace (i.e. it's several
+  // seconds beyond the just-rounded 5-min tick), push the anchor forward one
+  // interval so the reading lands cleanly inside slot 0's window.
+  if SortedReadings[0].date > anchorTime + RECENT_SLOT_GRACE_DAYS then
+    anchorTime := IncMinute(anchorTime, INTERVAL_MINUTES);
 
   TrndiDLog(Format('PlaceTrendDots: Processing %d readings, anchor=%s (latest=%s)',
     [Length(SortedReadings), DateTimeToStr(anchorTime), DateTimeToStr(SortedReadings[0].date)]));

--- a/units/trndi/api/trndi.api.dexcom.pp
+++ b/units/trndi/api/trndi.api.dexcom.pp
@@ -609,7 +609,6 @@ var
 begin
   // Initialize the noval
   noval.exists := false;
-  PrevVal := BG_NO_VAL;
   // Guard input ranges based on common Share limits
   if (AMinutes < 1) or (AMinutes > 1440) then
     raise Exception.Create('GetReadings error: AMinutes out of valid range (1..1440)');
@@ -686,17 +685,23 @@ begin
 
       if CurOk then
       begin
-        // Compute delta as current - previous valid reading
-        if FCalcDiff and (PrevVal <> BG_NO_VAL) then
-          Result[i].update(CurVal, CurVal - PrevVal)
+        // Dexcom Share returns readings newest-first, so the reading preceding
+        // this one in time is at index i+1. If the neighbor is missing, leave
+        // change = BG_NO_VAL (set by Init) so umain falls back to computing the
+        // delta from bgs[0] - bgs[1] instead of formatting a bogus 0.0.
+        if FCalcDiff and (i < LData.Count - 1) then
+        begin
+          PrevVal := SafeValue(LData.Items[i + 1], PrevOk);
+          if PrevOk then
+            Result[i].update(CurVal, CurVal - PrevVal)
+          else
+            Result[i].update(CurVal, BGPrimary);
+        end
         else
-          Result[i].update(CurVal, 0);
+          Result[i].update(CurVal, BGPrimary);
 
         // Classify level per thresholds
         Result[i].level := getLevel(Result[i].val);
-
-        // Update PrevVal for next delta
-        PrevVal := CurVal;
       end
       else
         Result[i].Clear// Missing value: clear the reading

--- a/units/trndi/api/trndi.api.dexcomNew.pp
+++ b/units/trndi/api/trndi.api.dexcomNew.pp
@@ -877,7 +877,6 @@ var
 begin
   // Initialize the noval
   noval.exists := false;
-  PrevVal := BG_NO_VAL;
   // Guard input ranges based on common Share limits
   if (AMinutes < 1) or (AMinutes > 1440) then
     raise Exception.Create('GetReadings error: AMinutes out of valid range (1..1440)');
@@ -965,17 +964,23 @@ begin
         else
           Result[i].date := 0;
 
-        // Compute delta as current - previous valid reading
-        if FCalcDiff and (PrevVal <> BG_NO_VAL) then
-          Result[i].update(CurVal, CurVal - PrevVal)
+        // Dexcom Share returns readings newest-first, so the reading preceding
+        // this one in time is at index i+1. If the neighbor is missing, leave
+        // change = BG_NO_VAL (set by Init) so umain falls back to computing the
+        // delta from bgs[0] - bgs[1] instead of formatting a bogus 0.0.
+        if FCalcDiff and (i < LData.Count - 1) then
+        begin
+          PrevVal := SafeValue(LData.Items[i + 1], PrevOk);
+          if PrevOk then
+            Result[i].update(CurVal, CurVal - PrevVal)
+          else
+            Result[i].update(CurVal, BGPrimary);
+        end
         else
-          Result[i].update(CurVal, 0);
+          Result[i].update(CurVal, BGPrimary);
 
         // Classify level per thresholds
         Result[i].level := getLevel(Result[i].val);
-
-        // Update PrevVal for next delta
-        PrevVal := CurVal;
       end
       else
         Result[i].Clear;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trend-dot placement so readings near 5-minute boundaries align more accurately.
  * Refined glucose change calculations for Dexcom readings, making displayed deltas more consistent when entries arrive in newest-first order.
  * Better handles missing neighboring readings, reducing incorrect or zeroed change values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->