### PR TITLE
Fix bug where Dexcom would reset once a day

### DIFF
--- a/inc/umain_glucose.inc
+++ b/inc/umain_glucose.inc
@@ -919,11 +919,25 @@ function TfBG.ApplyFetchedReadings(const Readings: BGResults;
 const ErrorMsg: string; Boot: boolean): boolean;
 var
   msg: string;
+  i: integer;
+  hasData: boolean;
 begin
   Result := false;
 
+  // A result set where every reading is a cleared placeholder (no value, no
+  // timestamp) is a failed fetch in disguise — e.g. a backend that mapped an
+  // error payload into readings. Treat it as empty so it can't masquerade as
+  // fresh data or displace the cached last-good readings below.
+  hasData := false;
+  for i := 0 to High(Readings) do
+    if not Readings[i].empty then
+    begin
+      hasData := true;
+      Break;
+    end;
+
   // Copy worker output into the main-thread bgs slot.
-  if Length(Readings) > 0 then
+  if hasData then
   begin
     SetLength(bgs, Length(Readings));
     Move(Readings[0], bgs[0], Length(Readings) * SizeOf(BGReading));

--- a/tests/api_dexcom_tests.pp
+++ b/tests/api_dexcom_tests.pp
@@ -6,7 +6,8 @@ interface
 
 uses
 Classes, SysUtils, fpcunit, testutils, testregistry,
-trndi.native, trndi.api, trndi.api.nightscout, trndi.api.dexcom, trndi.api.xdrip, trndi.types, dialogs, dateutils,
+trndi.native, trndi.api, trndi.api.nightscout, trndi.api.dexcom, trndi.api.dexcom_helpers,
+trndi.api.xdrip, trndi.types, dialogs, dateutils,
 test_server_helper;
 
 type
@@ -18,6 +19,8 @@ protected
 published
   procedure TestDexcom;
   procedure TestDexcomLocalServer;
+  procedure TestDexcomSessionFailureMatcher;
+  procedure TestDexcomExpiredSession;
 end;
 
 implementation
@@ -68,6 +71,65 @@ begin
       // so compare against local Now, not UTC.
       AssertTrue('Dexcom timestamp parses near current time',
         Abs(SecondsBetween(readings[0].date, Now)) < 3600);
+    finally
+      api.Free;
+    end;
+  finally
+    StopLocalTestServer;
+  end;
+end;
+
+procedure TAPIDexcomTester.TestDexcomSessionFailureMatcher;
+begin
+  // Dexcom sends CamelCase error codes without spaces; the matcher must catch
+  // them, not just the prose variants (regression: an expired session went
+  // undetected once a day, so the automatic re-login never fired).
+  AssertTrue('CamelCase SessionIdNotFound',
+    DexcomLooksLikeSessionFailure('{"Code":"SessionIdNotFound"}'));
+  AssertTrue('CamelCase SessionNotValid',
+    DexcomLooksLikeSessionFailure('{"Code":"SessionNotValid"}'));
+  AssertTrue('Prose session not found',
+    DexcomLooksLikeSessionFailure('Session ID not found'));
+  AssertTrue('Prose session is invalid',
+    DexcomLooksLikeSessionFailure('The session is invalid'));
+  AssertTrue('Account password error',
+    DexcomLooksLikeSessionFailure('{"Code":"AccountPasswordInvalid"}'));
+  AssertFalse('Glucose payload is not a session failure',
+    DexcomLooksLikeSessionFailure(
+    '[{"WT":"/Date(1610464324000)/","ST":"/Date(1610464324000)/","Value":120,"Trend":"Flat"}]'));
+  AssertFalse('Empty response is not a session failure',
+    DexcomLooksLikeSessionFailure(''));
+end;
+
+procedure TAPIDexcomTester.TestDexcomExpiredSession;
+var
+  api: TrndiAPI;
+  readings: BGResults;
+  BaseURL: string;
+begin
+  if GetEnvironmentVariable('TRNDI_NO_TESTSERVER') = '1' then
+  begin
+    Writeln('Skipping TestDexcomExpiredSession: embedded test server disabled (TRNDI_NO_TESTSERVER=1)');
+    Exit;
+  end;
+
+  if not StartOrUseTestServer(BaseURL) then
+    Fail('Failed to start or reach test server');
+
+  try
+    // The fake server issues session "EXPIRED-SESSION" to account "expired"
+    // and rejects it on the glucose endpoint with the real-world error object.
+    api := DexcomCustom.Create('expired', 'anypass', BaseURL + '/ShareWebServices/Services/');
+    try
+      AssertTrue('Dexcom connects (session issued)', api.connect);
+      readings := api.getReadings(30, 3, '');
+      // Regression: {"Code":"SessionIdNotFound",...} used to be iterated as
+      // readings (a JSON object's Count is its member count), fabricating
+      // cleared placeholders with date=0 that the UI rendered as a value of
+      // -50.2 mmol/L from 46211 days ago.
+      AssertEquals('Error object must not become readings', 0, Length(readings));
+      AssertTrue('errormsg carries the Dexcom error code',
+        Pos('SessionIdNotFound', api.errormsg) > 0);
     finally
       api.Free;
     end;

--- a/tests/testserver/pascal_testserver.pp
+++ b/tests/testserver/pascal_testserver.pp
@@ -371,7 +371,15 @@ begin
     begin
       sub := Copy(pathOnly, Length('/ShareWebServices/Services/') + 1, MaxInt);
       if sub = 'General/LoginPublisherAccountByName' then
-        SendResponse('application/json', '"TEST-DEXCOM-SESSION"')
+      begin
+        // Account "expired" simulates Dexcom Share's ~24h session expiry:
+        // login succeeds but the issued session is rejected by the glucose
+        // endpoint (see below).
+        if Pos('expired', LowerCase(Body)) > 0 then
+          SendResponse('application/json', '"EXPIRED-SESSION"')
+        else
+          SendResponse('application/json', '"TEST-DEXCOM-SESSION"');
+      end
       else if sub = 'General/SystemUtcTime' then
       begin
         ms := NowMillis;
@@ -379,6 +387,15 @@ begin
       end
       else if sub = 'Publisher/ReadPublisherLatestGlucoseValues' then
       begin
+        // Session ID may arrive in the query string (GET-style) or the POST
+        // body (form-encoded params); accept either.
+        if (Pos('sessionId=EXPIRED-SESSION', query) > 0) or
+          (Pos('sessionId=EXPIRED-SESSION', Body) > 0) then
+        begin
+          SendResponse('application/json',
+            '{"Code":"SessionIdNotFound","Message":"Session ID not found"}', 500);
+          Exit;
+        end;
         nowMs := NowMillis;
         items := '[';
         for i := 0 to 2 do

--- a/units/trndi/api/trndi.api.dexcom.pp
+++ b/units/trndi/api/trndi.api.dexcom.pp
@@ -536,20 +536,6 @@ out res: string; {%H-}noCache: boolean): BGResults;
 // not subject to HTTP GET caching. noCache is accepted for interface
 // compatibility but has no effect on this backend.
 
-function LooksLikeSessionFailure(const Response: string): boolean;
-var
-  L: string;
-begin
-  L := LowerCase(Response);
-  Result :=
-    ((Pos('session', L) > 0) and
-     ((Pos('invalid', L) > 0) or (Pos('expired', L) > 0) or
-      (Pos('not valid', L) > 0) or (Pos('not found', L) > 0))) or
-    (Pos('unauthorized', L) > 0) or
-    (Pos('forbidden', L) > 0) or
-    (Pos('accountpassword', L) > 0);
-end;
-
   // Helper: convert Dexcom /Date(ms)/ string to TDateTime.
   // Delegates to ParseDexcomTime so we handle the canonical "/Date(NNN)/" form
   // (parenthesis included), optional "+0000" offset suffixes, and ISO variants.
@@ -629,7 +615,7 @@ begin
 
     res := LGlucoseJSON;
 
-    if (attempt = 0) and LooksLikeSessionFailure(LGlucoseJSON) then
+    if (attempt = 0) and DexcomLooksLikeSessionFailure(LGlucoseJSON) then
       if Connect then
       begin
         LParams[1] := 'sessionId=' + FSessionID;
@@ -656,6 +642,22 @@ begin
       SetLength(Result, 0);
       Exit;
     end;
+  end;
+
+  // Readings must be a JSON array. Anything else — typically an error object
+  // like {"Code":"SessionIdNotFound","Message":...} — must not fall through to
+  // the loop below: an object's Count is its member count, so it would be
+  // mapped into cleared placeholder readings (val BG_NO_VAL, date 0) that
+  // downstream code renders as data from 1899.
+  if LData.JSONType <> jtArray then
+  begin
+    lastErr := Trim('Dexcom error: ' + Trim(SafeString(LData, 'Code') + ' ' +
+      SafeString(LData, 'Message')));
+    if lastErr = 'Dexcom error:' then
+      lastErr := 'Unexpected Dexcom response: ' + Copy(LGlucoseJSON, 1, 200);
+    LData.Free;
+    SetLength(Result, 0);
+    Exit;
   end;
 
   try

--- a/units/trndi/api/trndi.api.dexcomNew.pp
+++ b/units/trndi/api/trndi.api.dexcomNew.pp
@@ -802,20 +802,6 @@ out res: string; {%H-}noCache: boolean): BGResults;
 // not subject to HTTP GET caching. noCache is accepted for interface
 // compatibility but has no effect on this backend.
 
-function LooksLikeSessionFailure(const Response: string): boolean;
-var
-  L: string;
-begin
-  L := LowerCase(Response);
-  Result :=
-    ((Pos('session', L) > 0) and
-     ((Pos('invalid', L) > 0) or (Pos('expired', L) > 0) or
-      (Pos('not valid', L) > 0) or (Pos('not found', L) > 0))) or
-    (Pos('unauthorized', L) > 0) or
-    (Pos('forbidden', L) > 0) or
-    (Pos('accountpassword', L) > 0);
-end;
-
   // Helper: convert Dexcom /Date(ms)/ string to TDateTime.
   // Delegates to ParseDexcomTime so we handle the canonical "/Date(NNN)/" form
   // (parenthesis included), optional "+0000" offset suffixes, and ISO variants.
@@ -893,7 +879,7 @@ begin
     LGlucoseJSON := native.Request(true, DEXCOM_GLUCOSE_READINGS_ENDPOINT, LParams, '', 'Accept=application/json');
     res := LGlucoseJSON;
 
-    if (attempt = 0) and LooksLikeSessionFailure(LGlucoseJSON) then
+    if (attempt = 0) and DexcomLooksLikeSessionFailure(LGlucoseJSON) then
       if Connect then
       begin
         LParams[1] := 'sessionId=' + FSessionID;
@@ -935,6 +921,22 @@ begin
       SetLength(Result, 0);
       Exit;
     end;
+  end;
+
+  // Readings must be a JSON array. Anything else — typically an error object
+  // like {"Code":"SessionIdNotFound","Message":...} — must not fall through to
+  // the loop below: an object's Count is its member count, so it would be
+  // mapped into cleared placeholder readings (val BG_NO_VAL, date 0) that
+  // downstream code renders as data from 1899.
+  if LData.JSONType <> jtArray then
+  begin
+    lastErr := Trim('Dexcom error: ' + Trim(SafeString(LData, 'Code') + ' ' +
+      SafeString(LData, 'Message')));
+    if lastErr = 'Dexcom error:' then
+      lastErr := 'Unexpected Dexcom response: ' + Copy(LGlucoseJSON, 1, 200);
+    LData.Free;
+    SetLength(Result, 0);
+    Exit;
   end;
 
   try

--- a/units/trndi/api/trndi.api.dexcom_helpers.pp
+++ b/units/trndi/api/trndi.api.dexcom_helpers.pp
@@ -18,6 +18,13 @@ function JSONEscape(const S: string): string;
     names and converts them to the corresponding enum. }
 function MapDexcomTrendToEnum(const S: string): BGTrend;
 
+{** Heuristic: does a Dexcom Share response body indicate a dead/rejected
+    session (so the caller should re-authenticate)? Matches both prose
+    ("Session ID not found") and the CamelCase error codes Dexcom actually
+    sends ("SessionIdNotFound", "SessionNotValid") by comparing with spaces
+    stripped. }
+function DexcomLooksLikeSessionFailure(const Response: string): boolean;
+
 implementation
 
 function JSONEscape(const S: string): string;
@@ -100,6 +107,24 @@ begin
     Result := BGTrend(idx)
   else
     Result := TdPlaceholder;
+end;
+
+function DexcomLooksLikeSessionFailure(const Response: string): boolean;
+var
+  L: string;
+begin
+  // Strip spaces before lowercasing so "Session ID not found" and
+  // "SessionIdNotFound" both reduce to the same needle. Glucose payloads
+  // never contain the word "session", so this cannot misfire on real data.
+  L := LowerCase(StringReplace(Response, ' ', '', [rfReplaceAll]));
+  Result :=
+    ((Pos('session', L) > 0) and
+    ((Pos('invalid', L) > 0) or (Pos('expired', L) > 0) or
+    (Pos('notvalid', L) > 0) or (Pos('notfound', L) > 0) or
+    (Pos('sessionidnull', L) > 0))) or
+    (Pos('unauthorized', L) > 0) or
+    (Pos('forbidden', L) > 0) or
+    (Pos('accountpassword', L) > 0);
 end;
 
 end.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of expired or invalid Dexcom sessions.
  - Prevented error responses from being interpreted as glucose readings.
  - Avoided displaying placeholder or incorrectly dated readings when data is unavailable.
  - Improved detection of session failures across common Dexcom error formats.

- **Tests**
  - Added coverage for expired-session responses and non-reading error payloads.
  - Expanded simulated Dexcom server scenarios for session expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->