### PR TITLE
Fix/unison lazarus versions

### DIFF
--- a/.github/actions/setup-lazarus/action.yml
+++ b/.github/actions/setup-lazarus/action.yml
@@ -1,16 +1,25 @@
 name: Setup Lazarus/FPC
 description: Install Lazarus, FPC, and Qt6Pas (from the distro repos) on an Ubuntu runner.
 
+# This action owns the pinned Lazarus/FPC toolchain for linux amd64 (see the
+# DEFAULT_* values below). Every workflow that needs the toolchain calls it
+# without URLs and inherits that pin — there is deliberately no second copy to
+# keep in sync. Only a caller building for a *different* architecture (the
+# linux arm64 leg of build.yml) passes its own URLs.
+
 inputs:
   fpc_laz_url:
-    description: Download URL for the fpc-laz .deb package
-    required: true
+    description: Download URL for the fpc-laz .deb package. Empty = the pinned amd64 default.
+    required: false
+    default: ''
   fpc_src_url:
-    description: Download URL for the fpc-src .deb package
-    required: true
+    description: Download URL for the fpc-src .deb package. Empty = the pinned amd64 default.
+    required: false
+    default: ''
   laz_url:
-    description: Download URL for the lazarus-project .deb package
-    required: true
+    description: Download URL for the lazarus-project .deb package. Empty = the pinned amd64 default.
+    required: false
+    default: ''
   extra_packages:
     description: Additional apt packages to install alongside the base set (space-separated)
     required: false
@@ -21,8 +30,28 @@ runs:
   steps:
     - name: Install system packages and Lazarus/FPC
       shell: bash
+      env:
+        # ---- Pinned toolchain (linux amd64) -----------------------------
+        # Bump these three together; the weekly drift scan fails if a Lazarus
+        # version elsewhere under .github/ disagrees with them.
+        DEFAULT_FPC_LAZ_URL: https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.8/fpc-laz_3.2.2-210709_amd64.deb/download
+        DEFAULT_FPC_SRC_URL: https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.8/fpc-src_3.2.2-210709_amd64.deb/download
+        DEFAULT_LAZ_URL: https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.8/lazarus-project_4.8.0-0_amd64.deb/download
+        IN_FPC_LAZ_URL: ${{ inputs.fpc_laz_url }}
+        IN_FPC_SRC_URL: ${{ inputs.fpc_src_url }}
+        IN_LAZ_URL: ${{ inputs.laz_url }}
       run: |
         set -euo pipefail
+
+        # An unset matrix key expands to an empty string rather than dropping
+        # the input, so empty (not absent) is what selects the default.
+        FPC_LAZ_URL="${IN_FPC_LAZ_URL:-$DEFAULT_FPC_LAZ_URL}"
+        FPC_SRC_URL="${IN_FPC_SRC_URL:-$DEFAULT_FPC_SRC_URL}"
+        LAZ_URL="${IN_LAZ_URL:-$DEFAULT_LAZ_URL}"
+        echo "fpc-laz: $FPC_LAZ_URL"
+        echo "fpc-src: $FPC_SRC_URL"
+        echo "lazarus: $LAZ_URL"
+
         sudo apt-get update
         # Qt6Pas comes from the distro repos (libqt6pas6 runtime + libqt6pas-dev
         # headers) rather than pinned upstream .deb downloads.
@@ -33,8 +62,8 @@ runs:
           libcurl4-openssl-dev \
           ${{ inputs.extra_packages }}
 
-        curl -fsSL -o fpc-laz.deb "${{ inputs.fpc_laz_url }}"
-        curl -fsSL -o fpc-src.deb "${{ inputs.fpc_src_url }}"
-        curl -fsSL -o lazarus.deb "${{ inputs.laz_url }}"
+        curl -fsSL -o fpc-laz.deb "$FPC_LAZ_URL"
+        curl -fsSL -o fpc-src.deb "$FPC_SRC_URL"
+        curl -fsSL -o lazarus.deb "$LAZ_URL"
         sudo dpkg -i fpc-laz.deb fpc-src.deb lazarus.deb || true
         sudo apt-get -f install -y

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,9 @@ on:
 #    - Windows (x64)
 #    Each platform produces its own artifact (.zip, .deb/.rpm for Linux, .dmg for macOS)
 #
-# 3. "publish" job runs regardless of build outcome ("if: always()").
+# 3. "publish" job runs only when every build leg succeeded (no "if: always()").
+#    A failed leg would otherwise publish a release with that platform's assets
+#    silently missing.
 #    - Downloads all artifacts
 #    - Uses "find -type f" to upload only files to the release (avoids directory errors)
 #    - Updates or creates the GitHub release with the unified version number
@@ -30,6 +32,10 @@ concurrency:
   # Cancel superseded PR builds; never cancel main/release builds
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Least privilege by default; jobs that write opt in individually below.
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -37,6 +43,7 @@ jobs:
   # ===================== DETERMINE VERSION =====================
   version:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Only determine version for push events to main (skip for PRs)
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     outputs:
@@ -73,6 +80,13 @@ jobs:
     if: always()
     name: Build (${{ matrix.name }})
     runs-on: ${{ matrix.runner }}
+    # Well above the slowest leg (macOS, which builds its toolchain via
+    # MacPorts) but far below the 6h default a hung lazbuild would otherwise burn.
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      # The Windows leg pushes the NuGet package to GitHub Packages (main only).
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -89,9 +103,9 @@ jobs:
             # Preview image: needed for libqt6pas6/-dev, which only entered the
             # Ubuntu archive in 25.10 (not present on 24.04/ubuntu-latest).
             runner: ubuntu-26.04
-            fpc_laz_url: "https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.8/fpc-laz_3.2.2-210709_amd64.deb/download"
-            fpc_src_url: "https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.8/fpc-src_3.2.2-210709_amd64.deb/download"
-            laz_url: "https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.8/lazarus-project_4.8.0-0_amd64.deb/download"
+            # No toolchain URLs: amd64 inherits the pin owned by
+            # .github/actions/setup-lazarus, which every other workflow also
+            # uses. Only arm64 below needs its own (different architecture).
 
           # -------- Linux ARM64 --------
           - name: linux-arm64
@@ -203,15 +217,17 @@ jobs:
           # Build Trndi
           lazbuild --widgetset=qt6 --build-mode="Extensions (Release)" Trndi.lpi
 
-          # Run tests on pull requests (test runner embeds its own Pascal test server)
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            make test
-          fi
+          # Run tests on every event, not just PRs: a push to main publishes a
+          # release, so it is the last place that should skip the test gate.
+          # (The runner embeds its own Pascal test server.)
+          make test
 
           # Package portable ZIP (no PNG icon inside)
           mkdir -p artifacts
           cp Trndi artifacts/
-          [ -d "lang" ] && cp -r lang artifacts/
+          # `if` rather than `[ ... ] && cp`: under `set -e` a false test makes
+          # the AND-list return non-zero and kills the job with no message.
+          if [ -d "lang" ]; then cp -r lang artifacts/; fi
           # The binary carries an $ORIGIN runpath, so the QuickJS engine and its
           # ABI shim must travel beside it in every package layout below.
           # stage-qjs.sh installs the real library under its SONAME and skips the
@@ -234,7 +250,7 @@ jobs:
             PKG_DIR="pkgroot"
             mkdir -p "$PKG_DIR/usr/local/trndi"
             cp Trndi "$PKG_DIR/usr/local/trndi/"
-            [ -d "lang" ] && cp -r lang "$PKG_DIR/usr/local/trndi/"
+            if [ -d "lang" ]; then cp -r lang "$PKG_DIR/usr/local/trndi/"; fi
             sh dist/linux/stage-qjs.sh "$QJS_DIR" "$PKG_DIR/usr/local/trndi"
 
             # The CareLink login helper is compiled into the binary and written
@@ -255,7 +271,7 @@ jobs:
                 "$PKG_DIR/usr/local/share/trndi/kde-plasmoid/com.slicke.trndi.current"
             fi
             mkdir -p "$PKG_DIR/usr/share/pixmaps"
-            [ -f "Trndi.png" ] && cp Trndi.png "$PKG_DIR/usr/share/pixmaps/"
+            if [ -f "Trndi.png" ]; then cp Trndi.png "$PKG_DIR/usr/share/pixmaps/"; fi
             ICON=Trndi
             mkdir -p "$PKG_DIR/usr/share/applications"
             echo "[Desktop Entry]
@@ -291,8 +307,8 @@ jobs:
             echo "Packaging version: ${PKG_VERSION}"
 
             FPM_SCRIPTS=()
-            [ -f dist/linux/after-install.sh ] && FPM_SCRIPTS+=(--after-install dist/linux/after-install.sh)
-            [ -f dist/linux/after-remove.sh ] && FPM_SCRIPTS+=(--after-remove dist/linux/after-remove.sh)
+            if [ -f dist/linux/after-install.sh ]; then FPM_SCRIPTS+=(--after-install dist/linux/after-install.sh); fi
+            if [ -f dist/linux/after-remove.sh ]; then FPM_SCRIPTS+=(--after-remove dist/linux/after-remove.sh); fi
 
             fpm -s dir -t deb -n trndi -v "${PKG_VERSION}" --architecture "${DEB_ARCH}" --license "GPLv3" --description "Trndi CGM Viewer" "${FPM_SCRIPTS[@]}" -C "$PKG_DIR" .
             fpm -s dir -t rpm -n trndi -v "${PKG_VERSION}" --architecture "${RPM_ARCH}" --license "GPLv3" --description "Trndi CGM Viewer" "${FPM_SCRIPTS[@]}" -C "$PKG_DIR" .
@@ -470,8 +486,9 @@ jobs:
           # they must travel beside it in the portable ZIP. (dist/macos.sh does
           # the same for the .app bundle below.)
           cp externals/quickjs/prebuilt/aarch64-darwin/*.dylib artifacts/
-          [ -d "lang" ] && cp -r lang artifacts/
-          [ -f "dist/macos_README.txt" ] && cp dist/macos_README.txt artifacts/README.txt
+          # `if` rather than `[ ... ] && cp` — see the Linux packaging note above.
+          if [ -d "lang" ]; then cp -r lang artifacts/; fi
+          if [ -f "dist/macos_README.txt" ]; then cp dist/macos_README.txt artifacts/README.txt; fi
           # The CareLink login helper is compiled into the binary and written to
           # the user's writable settings folder on demand — nothing to bundle.
           7z a -tzip Trndi-macos-silicon.zip ./artifacts/* >/dev/null
@@ -511,13 +528,13 @@ jobs:
           # Windows resolves from the executable's own directory. Place them next
           # to Trndi.exe so the tests below and the packages built from here work.
           Copy-Item '.\externals\quickjs\prebuilt\x86_64-win64\*.dll' -Destination '.' -Force
-          # Run tests on pull requests via the same entry point developers use
-          # locally (test runner embeds its own Pascal test server). No extra
-          # args: make.ps1 forwards them to both lazbuild and the test exe.
-          if ("${{ github.event_name }}" -eq "pull_request") {
-            .\make.ps1 test
-            if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          }
+          # Run tests via the same entry point developers use locally (the test
+          # runner embeds its own Pascal test server). No extra args: make.ps1
+          # forwards them to both lazbuild and the test exe. Runs on every event,
+          # not just PRs — a push to main publishes a release, so it is the last
+          # place that should skip the test gate.
+          .\make.ps1 test
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
           # Package ZIP
           New-Item -ItemType Directory -Path artifacts -Force | Out-Null
           Copy-Item '.\Trndi.exe' -Destination '.\artifacts\'
@@ -590,11 +607,19 @@ jobs:
   # ===================== PUBLISH =====================
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: [version, build]
+    permissions:
+      # Creating/updating the GitHub Release and uploading its assets.
+      contents: write
     # Only create/update releases on direct pushes to main (not on pull_request events).
     # This is defense-in-depth: we removed `pull_request` from the workflow triggers above,
     # and additionally ensure the publish job only runs for push events to main.
-    if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    #
+    # Note the absence of always(): with it, a failed build leg still produced a
+    # release, just missing that platform's assets. Plain `needs` semantics skip
+    # this job unless every leg succeeded, which is what we want for a release.
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -842,6 +867,7 @@ jobs:
   # ===================== DISCORD NOTIFICATION =====================
   discord-notify:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: [version, publish]
     # Only notify on successful releases to main
     if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -432,7 +432,9 @@ jobs:
           sudo installer -pkg MacPorts.pkg -target /
           export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
           sudo port -v selfupdate
-          sudo port -N install fpc lazarus p7zip create-dmg
+          # gmake: the Makefile is GNU make syntax and macOS ships 3.81 as `make`
+          # (see CLAUDE.md — macOS uses gmake). Needed by the test step below.
+          sudo port -N install fpc lazarus p7zip create-dmg gmake
 
       - name: Write buildinfo (macOS)
         if: matrix.os_target == 'macos'
@@ -477,6 +479,15 @@ jobs:
           # unversioned (libqjs.dylib / libtqshim.dylib), so -lqjs links straight
           # against them — no symlink fixup is needed here, unlike on Linux.
           lazbuild --build-mode="Extensions (Release)" --ws=cocoa --cpu=aarch64 --os=darwin Trndi.lpi
+
+          # Run tests before packaging, as the Linux and Windows legs do. The
+          # Makefile's Darwin branch already resolves the cocoa widgetset and the
+          # aarch64-darwin QuickJS prebuilts, and TrndiTestConsole.lpi requires
+          # only FCL (no LCL), so this is a plain console run with no GUI session
+          # involved. It is also the first place CI actually *loads* the shipped
+          # dylibs rather than just linking them.
+          gmake test
+
           # Package zip & dmg (also on PRs, so packaging changes can be tested;
           # the publish job is gated on push-to-main, so PR artifacts only end up
           # attached to the workflow run, not a release).

--- a/.github/workflows/code-quality-scan.yml
+++ b/.github/workflows/code-quality-scan.yml
@@ -15,10 +15,6 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # Pinned Lazarus/FPC URLs — keep in sync with the linux-amd64 matrix entry in build.yml.
-  FPC_LAZ_URL: https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.8/fpc-laz_3.2.2-210709_amd64.deb/download
-  FPC_SRC_URL: https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.8/fpc-src_3.2.2-210709_amd64.deb/download
-  LAZ_URL: https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.8/lazarus-project_4.8.0-0_amd64.deb/download
 
 permissions:
   contents: read
@@ -31,15 +27,13 @@ jobs:
     # Preview image: needed for libqt6pas6/-dev (setup-lazarus), which only
     # entered the Ubuntu archive in 25.10 (not present on 24.04/ubuntu-latest).
     runs-on: ubuntu-26.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 
+      # Toolchain URLs come from the action's own pin — see setup-lazarus.
       - name: Install Lazarus/FPC toolchain
         uses: ./.github/actions/setup-lazarus
-        with:
-          fpc_laz_url: ${{ env.FPC_LAZ_URL }}
-          fpc_src_url: ${{ env.FPC_SRC_URL }}
-          laz_url: ${{ env.LAZ_URL }}
 
       - name: Build Pascal target and capture diagnostics
         run: |

--- a/.github/workflows/nightly-fpc-health.yml
+++ b/.github/workflows/nightly-fpc-health.yml
@@ -9,27 +9,24 @@ concurrency:
   group: trndi-nightly-fpc-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  # Pinned Lazarus/FPC URLs — keep in sync with the linux-amd64 matrix entry in build.yml.
-  FPC_LAZ_URL: https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.6/fpc-laz_3.2.2-210709_amd64.deb/download
-  FPC_SRC_URL: https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.6/fpc-src_3.2.2-210709_amd64.deb/download
-  LAZ_URL: https://sourceforge.net/projects/lazarus/files/Lazarus%20Linux%20amd64%20DEB/Lazarus%204.6/lazarus-project_4.6.0-0_amd64.deb/download
 
 jobs:
   fpc-console-health:
     # Preview image: needed for libqt6pas6/-dev (setup-lazarus), which only
     # entered the Ubuntu archive in 25.10 (not present on 24.04/ubuntu-latest).
     runs-on: ubuntu-26.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v5
 
+      # Toolchain URLs come from the action's own pin — see setup-lazarus.
       - name: Install FPC/Lazarus and test prerequisites
         uses: ./.github/actions/setup-lazarus
-        with:
-          fpc_laz_url: ${{ env.FPC_LAZ_URL }}
-          fpc_src_url: ${{ env.FPC_SRC_URL }}
-          laz_url: ${{ env.LAZ_URL }}
 
       - name: Show tool versions
         run: |

--- a/.github/workflows/weekly-fpc-drift.yml
+++ b/.github/workflows/weekly-fpc-drift.yml
@@ -9,12 +9,16 @@ concurrency:
   group: trndi-weekly-drift-${{ github.ref }}
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   toolchain-drift:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
@@ -75,12 +79,30 @@ jobs:
           echo "Summary: checked=$checked skipped=$skipped total=${#URLS[@]}" >> "$REPORT"
 
           echo >> "$REPORT"
-          echo "Pinned version hints (static excerpts from .github/workflows/build.yml; not execution logs):" >> "$REPORT"
+          echo "Pinned version hints (static excerpts from .github/; not execution logs):" >> "$REPORT"
           grep -rnE 'Lazarus%20[0-9]+\.[0-9]+|v[0-9]+\.[0-9]+\.[0-9]+|2\.3\.stable|fpc-laz_|qt6pas' .github/workflows/ .github/actions/ >> "$REPORT" || true
+
+          # Every download URL under .github/ must name the same Lazarus release.
+          # The amd64 pin lives in .github/actions/setup-lazarus; the arm64 leg
+          # and the Windows installer carry their own URLs and have silently
+          # fallen behind before (nightly sat on 4.6 while build.yml ran 4.8).
+          echo >> "$REPORT"
+          mapfile -t LAZ_VERSIONS < <(
+            { grep -rhoE 'Lazarus%20[0-9]+\.[0-9]+' .github/workflows/ .github/actions/ || true; } \
+              | sed 's/^Lazarus%20//' \
+              | sort -u
+          )
+          if [[ "${#LAZ_VERSIONS[@]}" -le 1 ]]; then
+            echo "Lazarus version consistency: OK (${LAZ_VERSIONS[*]:-none pinned})" >> "$REPORT"
+          else
+            echo "Lazarus version consistency: FAIL — multiple releases pinned: ${LAZ_VERSIONS[*]}" >> "$REPORT"
+            grep -rnE 'Lazarus%20[0-9]+\.[0-9]+' .github/workflows/ .github/actions/ >> "$REPORT"
+            FAIL=1
+          fi
 
           cat "$REPORT"
           if [[ "$FAIL" -ne 0 ]]; then
-            echo "One or more pinned URLs are unreachable. See report artifact." >&2
+            echo "Pinned URLs are unreachable and/or disagree on the Lazarus release. See report artifact." >&2
             exit 1
           fi
 

--- a/tests/mock/Controls.pp
+++ b/tests/mock/Controls.pp
@@ -97,6 +97,11 @@ type
     procedure Show; virtual;
     procedure SetFocus; virtual;
     procedure Update; virtual;
+    // Real LCL declares AdjustSize on TControl, so any control may be asked to
+    // re-run auto-sizing. Declared here (not just on TLabel) so mock TPaintBox
+    // and friends match: umain's macOS-only trend-dot path calls it on a
+    // TDotControl, which is a TPaintBox.
+    procedure AdjustSize; virtual;
     procedure Repaint; virtual;
     procedure Refresh; virtual;
     procedure SendToBack; virtual;
@@ -245,6 +250,13 @@ end;
 procedure TControl.SetFocus;
 begin
   // no-op for headless tests
+end;
+
+procedure TControl.AdjustSize;
+begin
+  // In real LCL this re-runs auto-sizing, which leaves a control whose AutoSize
+  // is off exactly as it was — the case for every mock control that does not
+  // override this. TLabel overrides it to measure its caption.
 end;
 
 procedure TControl.SetBounds(ALeft, ATop, AWidth, AHeight: Integer);

--- a/tests/mock/StdCtrls.pp
+++ b/tests/mock/StdCtrls.pp
@@ -20,7 +20,7 @@ type
   public
     constructor Create(AOwner: Controls.TComponent = nil);
     destructor Destroy; override;
-    procedure AdjustSize; // macOS AutoSize helper
+    procedure AdjustSize; override; // macOS AutoSize helper
     property Caption: string read FCaption write FCaption;
     property Font: TFont read FFont write FFont;
     property Alignment: Graphics.TAlignment read FAlignment write FAlignment;

--- a/tests/mock/trndi.native.mock.pp
+++ b/tests/mock/trndi.native.mock.pp
@@ -8,9 +8,17 @@ uses
   trndi.native.win,
 {$ELSEIF DEFINED(X_LINUXBSD)}
   trndi.native.linux,
+{$ELSEIF DEFINED(X_MAC)}
+  trndi.native.mac,
 {$ELSE}
+  // Every other platform (Haiku, ...) descends from the repo's
+  // platform-agnostic implementation rather than the abstract base: base's
+  // request/requestEx are deliberate "not implemented" stubs, so a mock rooted
+  // there fails every HTTP-backed test. trndi.native.generic is the same
+  // fphttpclient-based implementation trndi.native.haiku builds on.
   {$define TRNDI_NATIVE_MOCK_BASE}
   fphttpclient,
+  trndi.native.generic,
 {$ENDIF}
   trndi.native.base;
 
@@ -21,8 +29,10 @@ type
     TTrndiNativeWindows
     {$elseif defined(X_LINUXBSD)}
     TTrndiNativeLinux
+    {$elseif defined(X_MAC)}
+    TTrndiNativeMac
     {$else}
-    TTrndiNativeBase
+    TTrndiNativeGeneric
     {$endif}
   )
   private

--- a/units/misc/nsutils/nsutils.nsformat.pp
+++ b/units/misc/nsutils/nsutils.nsformat.pp
@@ -19,7 +19,11 @@ interface
 
 uses
   SysUtils,
-{$IF DEFINED(IPHONESIM) OR DEFINED(CPUARM) OR DEFINED(CPUAARCH64)}  //iOS
+{* Local change to this LGPL unit: detect iOS explicitly rather than treating
+   any AArch64 Darwin target as iOS, which breaks on Apple Silicon macOS.
+   This unit never had the LCLCOCOA escape the sibling units use, so it took
+   the iOS branch even in an LCL build. See nsutils.nshelpers.pp. *}
+{$IF DEFINED(IPHONESIM) OR DEFINED(IOS)}  //iOS
  {$IFDEF NoiPhoneAll}
   Foundation;
  {$ELSE}

--- a/units/misc/nsutils/nsutils.nshelpers.pp
+++ b/units/misc/nsutils/nsutils.nshelpers.pp
@@ -33,7 +33,13 @@ interface
 uses
   CFBase,
   CFString,
-  {$IF (DEFINED(IPHONESIM) OR DEFINED(CPUARM) OR DEFINED(CPUAARCH64)) AND (NOT DEFINED(LCLCOCOA)) }  //iOS
+  {* Local change to this LGPL unit: upstream treats any ARM/AArch64 Darwin
+     target as iOS, which predates Apple Silicon — on an M-series Mac
+     CPUAARCH64 is defined and the target is still macOS, so the iOS branch was
+     selected and iPhoneAll (which does not exist for macOS) failed to compile.
+     Only LCL builds escaped it, via the LCLCOCOA test below. Detect iOS
+     explicitly instead; Trndi builds no iOS target, so this branch is inert. *}
+  {$IF (DEFINED(IPHONESIM) OR DEFINED(IOS)) AND (NOT DEFINED(LCLCOCOA)) }  //iOS
  {$IFDEF NoiPhoneAll}
   Foundation;
  {$ELSE}

--- a/units/misc/nsutils/nsutils.nsmisc.pp
+++ b/units/misc/nsutils/nsutils.nsmisc.pp
@@ -24,7 +24,10 @@ interface
 
 uses
   SysUtils,
-{$IF (DEFINED(IPHONESIM) OR DEFINED(CPUARM) OR DEFINED(CPUAARCH64)) AND (NOT DEFINED(LCLCOCOA)) }  //iOS
+{* Local change to this LGPL unit: detect iOS explicitly rather than treating
+   any AArch64 Darwin target as iOS, which breaks on Apple Silicon macOS.
+   See nsutils.nshelpers.pp for the full note. *}
+{$IF (DEFINED(IPHONESIM) OR DEFINED(IOS)) AND (NOT DEFINED(LCLCOCOA)) }  //iOS
  {$IFDEF NoiPhoneAll}
   Foundation,
  {$ELSE}

--- a/units/misc/nsutils/nsutils.web.urlrequest.pp
+++ b/units/misc/nsutils/nsutils.web.urlrequest.pp
@@ -21,7 +21,10 @@ uses
 SysUtils,
 Classes,
 Math,
-{$IF (DEFINED(IPHONESIM) OR DEFINED(CPUARM) OR DEFINED(CPUAARCH64)) AND (NOT DEFINED(LCLCOCOA)) }  //iOS
+{* Local change to this LGPL unit: detect iOS explicitly rather than treating
+   any AArch64 Darwin target as iOS, which breaks on Apple Silicon macOS.
+   See nsutils.nshelpers.pp for the full note. *}
+{$IF (DEFINED(IPHONESIM) OR DEFINED(IOS)) AND (NOT DEFINED(LCLCOCOA)) }  //iOS
 {$IFDEF NoiPhoneAll}
 Foundation,
 {$ELSE}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Toolchain setup now provides pinned Linux defaults, so download URLs no longer need to be supplied manually.
  - macOS builds now run tests before packaging and can include the platform-specific README in release artifacts.

- **Bug Fixes**
  - Releases are published only after all build checks succeed.
  - Improved handling of optional packaging files prevents incomplete artifacts.
  - Toolchain health checks now detect inconsistent pinned Lazarus versions.

- **Chores**
  - Added workflow time limits and stricter permissions to improve CI reliability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->