### PR TITLE
CI: retry flaky toolchain downloads, add Dependabot for actions

### DIFF
--- a/.github/actions/setup-lazarus/action.yml
+++ b/.github/actions/setup-lazarus/action.yml
@@ -62,8 +62,12 @@ runs:
           libcurl4-openssl-dev \
           ${{ inputs.extra_packages }}
 
-        curl -fsSL -o fpc-laz.deb "$FPC_LAZ_URL"
-        curl -fsSL -o fpc-src.deb "$FPC_SRC_URL"
-        curl -fsSL -o lazarus.deb "$LAZ_URL"
+        # SourceForge mirrors flake; retry hard before failing the job.
+        # --retry-all-errors: also retry on non-transient responses (a mirror
+        # answering 403/503 for a moment), not just curl's default retry set.
+        CURL_RETRY="--retry 5 --retry-delay 5 --retry-all-errors"
+        curl -fsSL $CURL_RETRY -o fpc-laz.deb "$FPC_LAZ_URL"
+        curl -fsSL $CURL_RETRY -o fpc-src.deb "$FPC_SRC_URL"
+        curl -fsSL $CURL_RETRY -o lazarus.deb "$LAZ_URL"
         sudo dpkg -i fpc-laz.deb fpc-src.deb lazarus.deb || true
         sudo apt-get -f install -y

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep the actions used by .github/workflows/ current and on one version
+# (upload-artifact once sat on v5 in one workflow and v7 in another). The
+# composite actions in .github/actions/ contain no `uses:` steps, so scanning
+# the workflow directory ("/") covers everything. Toolchain download URLs are
+# watched separately by the weekly-fpc-drift workflow, not by Dependabot.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    # PRs land on develop first, like all other changes (see CLAUDE.md).
+    target-branch: develop

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -448,10 +448,13 @@ jobs:
             11) OSNAME="11-BigSur" ;;
             *) echo "Unsupported macOS version: ${OSMAJOR}" >&2; exit 1 ;;
           esac
-          # Fetch MacPorts installer directly from official site
-          PKG_URL="$(curl -fsSL https://www.macports.org/install.php | grep -Eo "https://[^\"[:space:]]*MacPorts-[0-9.]+-${OSNAME}\.pkg" | head -n1 || true)"
+          # Fetch MacPorts installer directly from official site. Retry hard:
+          # a transient failure here kills the whole leg (see setup-lazarus for
+          # the same treatment of the SourceForge downloads).
+          CURL_RETRY="--retry 5 --retry-delay 5 --retry-all-errors"
+          PKG_URL="$(curl -fsSL $CURL_RETRY https://www.macports.org/install.php | grep -Eo "https://[^\"[:space:]]*MacPorts-[0-9.]+-${OSNAME}\.pkg" | head -n1 || true)"
           [ -n "$PKG_URL" ] || { echo "Failed to resolve MacPorts pkg URL" >&2; exit 1; }
-          curl -fsSL -o MacPorts.pkg "$PKG_URL"
+          curl -fsSL $CURL_RETRY -o MacPorts.pkg "$PKG_URL"
           sudo installer -pkg MacPorts.pkg -target /
           export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
           sudo port -v selfupdate
@@ -552,7 +555,9 @@ jobs:
           # Invoke-WebRequest can do this too, but only with an explicit
           # -UserAgent holding a non-browser token — easy to "clean up" later
           # and silently start downloading a web page, hence the MZ check below.
-          curl.exe -L --fail -o lazarus-4.8.exe "https://sourceforge.net/projects/lazarus/files/Lazarus%20Windows%2064%20bits/Lazarus%204.8/lazarus-4.8-fpc-3.2.2-win64.exe/download"
+          # Retry hard: SourceForge mirrors flake, and a transient failure here
+          # kills the whole leg (same treatment as setup-lazarus on Linux).
+          curl.exe -L --fail --retry 5 --retry-delay 5 --retry-all-errors -o lazarus-4.8.exe "https://sourceforge.net/projects/lazarus/files/Lazarus%20Windows%2064%20bits/Lazarus%204.8/lazarus-4.8-fpc-3.2.2-win64.exe/download"
           # --fail rejects HTTP errors, but a mirror answering 200 with an HTML
           # page would still land here and fail confusingly at install time.
           # Check the MZ header so a bad download fails loudly and immediately.

--- a/.github/workflows/weekly-fpc-drift.yml
+++ b/.github/workflows/weekly-fpc-drift.yml
@@ -105,7 +105,7 @@ jobs:
         # to upload on failure too — otherwise the report is missing in exactly
         # the case someone needs to read it.
         if: ${{ always() }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: weekly-fpc-drift-report
           path: build/weekly-drift-report.txt


### PR DESCRIPTION
Every external fetch that can kill a build leg (SourceForge .debs and the Windows Lazarus installer, the MacPorts scrape/pkg) now retries hard, including on momentary 403/503 mirror responses. New Dependabot config keeps workflow action versions current and consistent; bump the drift workflow's upload-artifact v5 to v7 to match build.yml until it takes over.