### PR TITLE
Cache the Linux global-menu and dark-mode probes

### DIFF
--- a/inc/umain_init.inc
+++ b/inc/umain_init.inc
@@ -779,8 +779,8 @@ begin
   InitializePlatformMenus;
   {$endif}
   {$ifdef X_LINUXBSD}
-  if TrndiNative.HasGlobalMenu then
-    InitializePlatformMenus;
+  // InitializePlatformMenus gates on native.HasGlobalMenu itself.
+  InitializePlatformMenus;
   {$endif}
 
   if ssShift in GetKeyShiftState then

--- a/inc/umain_timers.inc
+++ b/inc/umain_timers.inc
@@ -951,6 +951,9 @@ begin
   if FShuttingDown then
     Exit;
   TrndiDLog('OnSystemWake: OS reported resume-from-sleep — forcing refresh');
+  // The desktop theme may have flipped while asleep (scheduled dark mode);
+  // the next setColorMode should ask again rather than trust the cache.
+  TrndiNative.InvalidateThemeCache;
   FForceRefresh := true;
   if firstboot then
     Exit;

--- a/units/trndi/trndi.native.base.pp
+++ b/units/trndi/trndi.native.base.pp
@@ -323,6 +323,10 @@ class var touchOverride: TTrndiBool;
     // Theme/Env
     {** Determine if the OS/theme uses a dark appearance. Platforms override. }
   class function isDarkMode: boolean; virtual;
+    {** Forget any cached theme probe so the next @link(isDarkMode) asks the
+        desktop again. Called on resume-from-sleep; a no-op on platforms whose
+        detection is cheap enough not to cache. }
+  class procedure InvalidateThemeCache; virtual;
     {** Ask the platform to apply a dark appearance. @param(winHandle) is the
         native window handle for platforms that theme per-window (Windows
         DWM); 0 targets nothing/the app default — the same PtrUInt
@@ -1945,6 +1949,15 @@ end;
 class function TTrndiNativeBase.isDarkMode: boolean;
 begin
   Result := DefaultIsDarkMode;
+end;
+
+{------------------------------------------------------------------------------
+  InvalidateThemeCache (class, virtual)
+  -------------------------------------
+  Base: nothing is cached, so nothing to drop.
+ ------------------------------------------------------------------------------}
+class procedure TTrndiNativeBase.InvalidateThemeCache;
+begin
 end;
 
 {------------------------------------------------------------------------------

--- a/units/trndi/trndi.native.linux.pp
+++ b/units/trndi/trndi.native.linux.pp
@@ -243,6 +243,8 @@ public
     5) Fallback heuristic comparing clWindow vs clWindowText brightness.
   }
   class function isDarkMode: boolean; override;
+    {** Drops the cached @link(isDarkMode) answer so the next call re-probes. }
+  class procedure InvalidateThemeCache; override;
     {** Returns True if notify-send is available on this system. }
   class function isNotificationSystemAvailable: boolean; override;
     {** Identify notification backend: 'dbus' or 'gdbus' (the Qt6 bus paths),
@@ -527,6 +529,10 @@ end;
   the Qt tool is only a fallback, and its binary name varies by distro
   (plain `qdbus` does not exist on e.g. Fedora KDE, which ships `qdbus-qt6`).
  ------------------------------------------------------------------------------}
+var
+gGlobalMenuProbed: boolean = false;
+gGlobalMenuResult: boolean = false;
+
 class function TTrndiNativeLinux.HasGlobalMenu: boolean;
 const
   QDBUS_NAMES: array[0..4] of string =
@@ -550,14 +556,27 @@ var
       (Pos('org.kde.appmenu', lower) > 0);
   end;
 
+  // Every probe below is a subprocess with a multi-second timeout, and the
+  // answer cannot change for the lifetime of the process (the menu bar is
+  // built once from it). Startup used to pay the full chain twice.
+  function Remember(const v: boolean): boolean;
+  begin
+    gGlobalMenuResult := v;
+    gGlobalMenuProbed := true;
+    Result := v;
+  end;
+
 begin
+  if gGlobalMenuProbed then
+    Exit(gGlobalMenuResult);
+
   Result := False;
 
   toolPath := FindInPath('busctl');
   if toolPath <> '' then
     if RunAndCaptureSimpleWait(toolPath, ['--user', '--no-pager', '--acquired', 'list'],
       outS, exitCode, 7000) and (exitCode = 0) and HasRegistrar(outS) then
-      Exit(True);
+      Exit(Remember(True));
 
   toolPath := FindInPath('gdbus');
   if toolPath <> '' then
@@ -566,7 +585,7 @@ begin
       '--object-path', '/org/freedesktop/DBus',
       '--method', 'org.freedesktop.DBus.ListNames'],
       outS, exitCode, 7000) and (exitCode = 0) and HasRegistrar(outS) then
-      Exit(True);
+      Exit(Remember(True));
 
   for i := Low(QDBUS_NAMES) to High(QDBUS_NAMES) do
   begin
@@ -575,14 +594,14 @@ begin
       Continue;
     if RunAndCaptureSimpleWait(toolPath, [], outS, exitCode, 7000) and
       (exitCode = 0) and HasRegistrar(outS) then
-      Exit(True);
+      Exit(Remember(True));
   end;
 
   // GTK module hint: only match explicit appmenu-gtk module, not the generic 'appmenu' substring
   gtkMods := LowerCase(GetEnvironmentVariable('GTK_MODULES'));
   if gtkMods <> '' then
     if Pos('appmenu-gtk', gtkMods) > 0 then
-      Exit(True);
+      Exit(Remember(True));
 
   // Do NOT use KDE plasmoid presence as a global-menu indicator:
   // the plasmoid may be visible for display purposes without a desktop
@@ -591,7 +610,7 @@ begin
   // Do NOT check for appmenu helper tools on PATH; their presence does not
   // guarantee a working global menu bar integration.
 
-  Result := False;
+  Result := Remember(False);
 end;
 
 // (CurlWriteCallback_Linux moved to trndi.native.request.curl as
@@ -1126,7 +1145,45 @@ end;
   Desktop-aware detection: portal (gdbus), KDE (kreadconfig6/5), GNOME
   (gsettings), GTK_THEME, or fallback luminance heuristic.
  ------------------------------------------------------------------------------}
+var
+gDarkModeCached: boolean = false;
+gDarkModeCheckedAt: QWord = 0;
+gDarkModeValid: boolean = false;
+
+function DetectDarkModeUncached: boolean; forward;
+
 class function TTrndiNativeLinux.isDarkMode: boolean;
+const
+  // Every probe below is a bus call or a subprocess with a multi-second
+  // timeout. The value is read by every TrndiNative constructor (four of
+  // them at boot), by setColorMode on every reading and by each alert
+  // dialog, so it is cached like ShouldSuppressTrayIcon. There is no theme
+  // change signal on Linux; a switch is picked up within the TTL, which is
+  // sooner than the once-per-reading cadence that used to notice it.
+  DARK_MODE_TTL_MS = 30000;
+begin
+  if gDarkModeValid and
+    (GetTickCount64 - gDarkModeCheckedAt < DARK_MODE_TTL_MS) then
+    Exit(gDarkModeCached);
+
+  Result := DetectDarkModeUncached;
+
+  gDarkModeCached := Result;
+  gDarkModeCheckedAt := GetTickCount64;
+  gDarkModeValid := true;
+end;
+
+class procedure TTrndiNativeLinux.InvalidateThemeCache;
+begin
+  gDarkModeValid := false;
+end;
+
+{------------------------------------------------------------------------------
+  DetectDarkModeUncached
+  ----------------------
+  The actual probe chain behind isDarkMode.
+ ------------------------------------------------------------------------------}
+function DetectDarkModeUncached: boolean;
 var
   v: boolean;
   envGtkTheme: string;


### PR DESCRIPTION
HasGlobalMenu spawns busctl/gdbus/qdbus with 7 s timeouts and was called
twice during FormCreate; the answer cannot change within a process, so
remember it. isDarkMode runs a bus call plus kreadconfig/gsettings
subprocesses and is evaluated by every TrndiNative constructor (four at
boot), by setColorMode on every reading and by each alert dialog; cache it
for 30 s and drop the cache on resume-from-sleep via a new virtual
InvalidateThemeCache.
