### PR TITLE
Run the boot api.Connect on the fetch worker

### DIFF
--- a/inc/umain_async.inc
+++ b/inc/umain_async.inc
@@ -369,13 +369,17 @@ end;
   UI stays responsive while the network round-trip is in flight.
  ------------------------------------------------------------------------------}
 constructor TGlucoseFetchThread.Create(AOwner: TfBG; Boot: boolean;
-Force: boolean);
+Force: boolean; ConnectFirst: boolean);
 begin
   inherited Create(true);
   FreeOnTerminate := false;
   FOwner := AOwner;
   FBoot := Boot;
   FForce := Force;
+  FConnectFirst := ConnectFirst;
+  FConnectOK := false;
+  FConnectErr := '';
+  FAbortFetch := false;
   FErrorMsg := '';
   SetLength(FResults, 0);
   Start;
@@ -391,6 +395,34 @@ begin
     try
       if not Assigned(api) then
         Exit;
+
+      // Boot: api.Connect used to run synchronously inside FormCreate, before
+      // the window existed — a slow network or CareLink's multi-step login
+      // meant an icon in the taskbar and nothing else. It runs here now.
+      // The thresholds it fills in are needed before getReadings stamps
+      // levels, so the main thread applies them (ApplyConnectResult) between
+      // the two calls.
+      if FConnectFirst then
+      begin
+        try
+          FConnectOK := api.Connect;
+          if not FConnectOK then
+            FConnectErr := api.errormsg;
+        except
+          on E: Exception do
+          begin
+            FConnectOK := false;
+            FConnectErr := E.ClassName + ': ' + E.Message;
+          end;
+        end;
+        if Terminated then
+          Exit;
+        Synchronize(@ApplyConnectResult);
+        // The failure path frees and replaces api once this worker has
+        // unwound; nothing below may touch it when FAbortFetch is set.
+        if FAbortFetch or (not FConnectOK) or Terminated then
+          Exit;
+      end;
 
       {$ifdef DEBUG}
       FResults := api.getReadings(MAX_MIN, MAX_RESULT, '', FDiag, FForce);
@@ -417,9 +449,45 @@ begin
       end;
     end;
   finally
-    if not Terminated then
+    if (not Terminated) and (not FAbortFetch) then
       Synchronize(@ApplyResult);
   end;
+end;
+
+// Main thread, between the worker's Connect and its getReadings.
+procedure TGlucoseFetchThread.ApplyConnectResult;
+begin
+  if not Assigned(FOwner) then
+  begin
+    FAbortFetch := true;
+    Exit;
+  end;
+
+  if FOwner.FShuttingDown then
+  begin
+    FAbortFetch := true;
+    FOwner.FApiCallInFlight := false;
+    if FBoot then
+      FOwner.FBootFetchPending := false;
+    Exit;
+  end;
+
+  if FConnectOK then
+  begin
+    FOwner.FBootConnectPending := false;
+    FOwner.ApplyConnectedApi;
+    Exit;
+  end;
+
+  // Failure. Release the api gate here, but run the dialogs from the message
+  // loop rather than from inside this Synchronize: they are modal, and a
+  // worker parked in Synchronize for the length of a Settings session would
+  // stall a quit from that dialog until the fetch-shutdown timeout detached
+  // it. The boot spinner keeps running; the retry re-enters the boot path.
+  FAbortFetch := true;
+  FOwner.FApiCallInFlight := false;
+  FOwner.FBootConnectError := FConnectErr;
+  Application.QueueAsyncCall(@FOwner.DeferredBootConnectFailure, 0);
 end;
 
 procedure TGlucoseFetchThread.ApplyResult;

--- a/inc/umain_ext.inc
+++ b/inc/umain_ext.inc
@@ -363,8 +363,12 @@ begin
     fSplash.incProgress(79, 'Initializing extensions backend..');
 
   // Safe mode: holding Ctrl during startup skips all extension loading.
-  if ssCtrl in GetKeyShiftState then
+  // Boot samples the key at the top of FormCreate (FSafeModeRequested): the
+  // load itself now runs seconds later, after the backend connected, and the
+  // user has long let go by then. A live Ctrl still counts for manual reloads.
+  if FSafeModeRequested or (ssCtrl in GetKeyShiftState) then
   begin
+    FSafeModeRequested := false;
     SlickeHTMLMsg(sdsAuto, RS_SAFEMODE, RS_SAFEMODE_DESC, [mbOK], uxmtInformation, uxscLarge);
     exts.Free;
     Exit;

--- a/inc/umain_glucose.inc
+++ b/inc/umain_glucose.inc
@@ -1583,6 +1583,16 @@ begin
   if api = nil then
     Exit;
 
+  // Until the boot worker's Connect has succeeded only the boot fetch itself
+  // may use the backend: a periodic tick landing while the connect-failure
+  // Settings dialog is up would otherwise fetch against a backend that never
+  // connected, or against one that is about to be replaced.
+  if FBootConnectPending and (not Boot) then
+  begin
+    TrndiDLog('RequestAsyncFetch: dropped — boot connect still pending');
+    Exit;
+  end;
+
   if FApiCallInFlight then
   begin
     TrndiDLog('RequestAsyncFetch: dropped — api call already in flight');
@@ -1631,7 +1641,8 @@ begin
   TrndiDLog('RequestAsyncFetch: starting worker (boot=' +
     BoolToStr(Boot, true) + ' force=' + BoolToStr(Force, true) + ')');
 
-  FGlucoseFetchThread := TGlucoseFetchThread.Create(Self, Boot, Force);
+  FGlucoseFetchThread := TGlucoseFetchThread.Create(Self, Boot, Force,
+    Boot and FBootConnectPending);
   Result := true;
 end;
 

--- a/inc/umain_helpers.inc
+++ b/inc/umain_helpers.inc
@@ -50,6 +50,33 @@ end;
 
 procedure TfBG.APIReceiver(const msg: string; etype: TrndiAPIMsg);
 begin
+  // Backends emit from whichever thread runs them — Connect and getReadings
+  // both live on the fetch worker — and alert/notice end in LCL calls. Hand
+  // those to the main thread and let the worker wait. FApiCallInFlight keeps
+  // one worker on the api at a time, so a single marshal slot suffices. A
+  // worker detached at shutdown must not block on a main loop that is gone.
+  if GetCurrentThreadId <> MainThreadID then
+  begin
+    if FShuttingDown then
+    begin
+      TrndiDLog(msg);
+      Exit;
+    end;
+    FPendingApiMsg := msg;
+    FPendingApiMsgType := etype;
+    TThread.Synchronize(TThread.CurrentThread, @DeliverPendingApiMessage);
+    Exit;
+  end;
+  DeliverApiMessage(msg, etype);
+end;
+
+procedure TfBG.DeliverPendingApiMessage;
+begin
+  DeliverApiMessage(FPendingApiMsg, FPendingApiMsgType);
+end;
+
+procedure TfBG.DeliverApiMessage(const msg: string; etype: TrndiAPIMsg);
+begin
   case etype of
   TrndiAPIMsg.alert:
     SlickeMessage('API Alert', msg, uxmtWarning);

--- a/inc/umain_init.inc
+++ b/inc/umain_init.inc
@@ -528,15 +528,22 @@ begin
     end;
   end;
 
-  // Scale MAX_RESULT to the API's reporting frequency so all dot slots can be
+  // Ensure MAX_MIN and MAX_RESULT cover the full dot window, then scale
+  // MAX_RESULT to the API's reporting frequency so all dot slots can be
   // filled even for backends that upload more often than every 5 minutes.
-  // Formula: 25 × ceil(INTERVAL_MINUTES / reportingInterval)
+  // Formula: max(25, ACTIVE_DOTS) × ceil(INTERVAL_MINUTES / reportingInterval)
   //   5-min backend → 25 × 1 = 25
   //   1-min backend → 25 × 5 = 125
+  // getReportingInterval is a backend constant, so this needs no Connect.
   if Assigned(api) then
+  begin
+    if MAX_MIN < ACTIVE_DOTS * INTERVAL_MINUTES + 10 then
+      MAX_MIN := ACTIVE_DOTS * INTERVAL_MINUTES + 10;
     MAX_RESULT := Max(MAX_RESULT,
-      25 * Max(1, (INTERVAL_MINUTES + api.getReportingInterval - 1)
-                   div api.getReportingInterval));
+      Max(25, ACTIVE_DOTS) *
+      Max(1, (INTERVAL_MINUTES + api.getReportingInterval - 1)
+        div api.getReportingInterval));
+  end;
 end;
 
 {$ifdef X_LINUXBSD}
@@ -649,21 +656,8 @@ end;
 
 // Initialize the TrendDots array in FormCreate
 procedure TfBG.FormCreate({%H-}Sender: TObject);
-procedure haltBoot;
-  begin
-    firstboot := true;
-    fSplash.Hide;
-    FreeAndNil(fSplash);
-    tMain.Enabled := false;
-    lArrow.Caption := '';
-    lVal.Caption := RS_SETUP;
-    lVal.Cursor := crHandPoint;
-    bSettings.Show;
-    LayoutSetupScreen;
-  end;
-
 var
-  guifontName, txtfontName, apiTarget, prevSetup: string;
+  guifontName, txtfontName, apiTarget: string;
   fil, englishOnce: boolean;
   userlocale: TFormatSettings;
   minutesStr: string;
@@ -675,6 +669,9 @@ var
 begin
   TrndiDLog(Format(#10'=== Trndi started at %s ===', [DateTimeToStr(Now)]));
   firstboot := false;
+  // Extension safe mode is decided by the key state at launch, not at the
+  // (now deferred) moment the extensions load.
+  FSafeModeRequested := ssCtrl in GetKeyShiftState;
 
   // Assigned here rather than in the LFM: it pairs with the wsMinimized guard
   // in tResizeTimer, which is the only reason the event is wanted at all.
@@ -923,7 +920,7 @@ begin
     Application.ProcessMessages;
     if not InitializeAPI then
     begin
-      haltBoot;
+      EnterSetupScreen;
       Exit;
     end;
 
@@ -955,56 +952,16 @@ begin
 
     api.APIEmitter := @APIReceiver;
     api.OnCredentialsChanged := @APICredentialsChanged;
-    // A failed Connect at boot (e.g. an expired CareLink token) lands the
-    // user directly in Settings; the main window is never shown. New backend
-    // settings are retried in place, closing Settings unchanged quits.
-    while not api.Connect do
-    begin
-      fSplash.Hide;
-      ShowMessage(api.ErrorMsg);
-
-      prevSetup := GetSetting('remote.type') + '|' + GetSetting('remote.target') +
-        '|' + GetSetting('remote.creds');
-      firstboot := true; // Settings saves silently and leaves fBG hidden
-      miSettings.Click;
-      firstboot := false;
-
-      if GetSetting('remote.type') + '|' + GetSetting('remote.target') +
-        '|' + GetSetting('remote.creds') = prevSetup then
-      begin
-        firstboot := true; // Ensure quit doesn't ask for confirmation
-        FCloseAfterFormCreate := true;
-        Application.ShowMainForm := false;
-        Application.Terminate;
-        FreeAndNil(fSplash);
-        Exit;
-      end;
-
-      FreeAndNil(api);
-      if not InitializeAPI then
-      begin
-        haltBoot;
-        Exit;
-      end;
-      api.APIEmitter := @APIReceiver;
-      api.OnCredentialsChanged := @APICredentialsChanged;
-      fSplash.Show;
-    end;
+    // api.Connect runs on the boot worker (TGlucoseFetchThread with
+    // ConnectFirst), so the window is up and painting while the backend
+    // answers. ApplyConnectedApi finishes the threshold-dependent setup once
+    // it succeeds; DeferredBootConnectFailure runs the "error, Settings,
+    // retry or quit" flow when it does not.
+    FBootConnectPending := true;
 
     fSplash.incProgress(70, RS_INIT_UX);
     // UI preferences
     DOT_ADJUST := GetFloatSetting('ux.dot_adjust', 0);
-
-    // Ensure MAX_MIN and MAX_RESULT cover the full dot window.
-    // ACTIVE_DOTS was read before CreateTrendDots; the API-based MAX_RESULT
-    // scaling earlier used a default dot count — bump it for higher counts.
-    // MAX_RESULT is a reading count; mirror InitializeAPI's reporting-interval
-    // scaling but with ACTIVE_DOTS as the base.
-    if MAX_MIN < ACTIVE_DOTS * INTERVAL_MINUTES + 10 then
-      MAX_MIN := ACTIVE_DOTS * INTERVAL_MINUTES + 10;
-    MAX_RESULT := Max(MAX_RESULT,
-      ACTIVE_DOTS * Max(1, (INTERVAL_MINUTES + api.getReportingInterval - 1)
-                   div api.getReportingInterval));
 
     DIFF_ALIGN := native.GetAlignmentSetting('ux.labels.ldiff.alignment', taCenter);
 
@@ -1014,31 +971,8 @@ begin
     PaintRange := GetBoolSetting('ux.paint_range', true);
     PaintRangeLines := GetBoolSetting('ux.paint_range_lines', false);
     PaintRangeCGMRange := GetBoolSetting('ux.paint_range_cgmrange', false);
-    // Extensions
-    {$ifdef TrndiExt}
-    fSplash.incProgress(80, RS_SPLASH_LOADING_INIT);
-    LoadExtensions;
-    {$endif}
-
-    // Apply wizard-suggested thresholds for APIs that don't supply their own
-    // (cgmHi stays at initCGMCore's sentinel 401 when the API never set it)
-    if api.cgmHi = 401 then
-    begin
-      api.cgmHi := GetIntSetting('wizard.hi', api.cgmHi);
-      api.cgmLo := GetIntSetting('wizard.lo', api.cgmLo);
-    end;
-
-    fSplash.incProgress(85, RS_INIT_CUSTOM_OVERRIDES);
-    // Override settings - always apply if set, regardless of checkbox state
-    // This allows extensions and manual config edits to work
-    api.cgmLo := GetIntSetting('override.lo', api.cgmLo);
-    api.cgmHi := GetIntSetting('override.hi', api.cgmHi);
-    api.cgmRangeLo := GetIntSetting('override.rangelo', api.cgmRangeLo);
-    api.cgmRangeHi := GetIntSetting('override.rangehi', api.cgmRangeHi);
-
-    // Thresholds are final now - give the alert engine the same limits the UI
-    // paints with.
-    SeedLevelAlertRules;
+    // Extensions and the threshold fix-ups (wizard fallback, overrides, alert
+    // seeding) wait for the backend: see ApplyConnectedApi.
 
     PredictGlucoseReading := GetBoolSetting('predictions.enable', false);
     PredictShortMode := GetBoolSetting('predictions.short', false);
@@ -1095,7 +1029,7 @@ begin
   lArrow.Caption := '';
   lDiff.Caption := '';
   lRef.Caption := '';
-  SetAgoText(RS_INIT_FETCH, '');
+  SetAgoText(RS_INIT_CONNECT, '');
   FTirBadge.Clear;
   if Assigned(pnOffReading) then
     pnOffReading.Visible := false;
@@ -1117,16 +1051,12 @@ begin
   // message loop run first guarantees the form is painted and interactive
   // before any threading machinery starts.
   //
-  // Note: Enabled stays false here. The explicit Application.ProcessMessages
-  // further down (and any implicit pumping from fSplash.FadeOutAndClose /
-  // Self.Show)
-  // would otherwise dispatch this 50 ms WM_TIMER while FormCreate is still
-  // mid-setup. Arming happens at the very end of FormCreate.
+  // Note: the timer is not created here. The explicit
+  // Application.ProcessMessages further down (and any implicit pumping from
+  // fSplash.FadeOutAndClose / Self.Show) would otherwise dispatch its 50 ms
+  // WM_TIMER while FormCreate is still mid-setup. ArmBootFetch runs at the
+  // very end of FormCreate.
   FBootFetchPending := true;
-  tBootFetch := TTimer.Create(Self);
-  tBootFetch.Interval := 50;
-  tBootFetch.OnTimer := @tBootFetchTimer;
-  tBootFetch.Enabled := false;
 
   tBootSpinner := TTimer.Create(Self);
   tBootSpinner.Interval := 100;
@@ -1253,8 +1183,122 @@ begin
   // Application.ProcessMessages in FormCreate, so tBootFetchTimer cannot
   // fire until FormCreate returns and Application.Run starts pumping —
   // i.e. the form is fully constructed before any worker thread spawns.
-  if Assigned(tBootFetch) then
-    tBootFetch.Enabled := true;
+  ArmBootFetch(50);
+end;
+
+// Main thread, from the boot worker's Synchronize, after api.Connect
+// succeeded and before its getReadings. Everything here used to sit inline
+// in FormCreate behind the synchronous Connect.
+procedure TfBG.ApplyConnectedApi;
+begin
+  // Apply wizard-suggested thresholds for APIs that don't supply their own
+  // (cgmHi stays at initCGMCore's sentinel 401 when the API never set it)
+  if api.cgmHi = 401 then
+  begin
+    api.cgmHi := native.GetIntSetting('wizard.hi', api.cgmHi);
+    api.cgmLo := native.GetIntSetting('wizard.lo', api.cgmLo);
+  end;
+
+  // Override settings - always apply if set, regardless of checkbox state
+  // This allows extensions and manual config edits to work
+  api.cgmLo := native.GetIntSetting('override.lo', api.cgmLo);
+  api.cgmHi := native.GetIntSetting('override.hi', api.cgmHi);
+  api.cgmRangeLo := native.GetIntSetting('override.rangelo', api.cgmRangeLo);
+  api.cgmRangeHi := native.GetIntSetting('override.rangehi', api.cgmRangeHi);
+
+  // Thresholds are final now - give the alert engine the same limits the UI
+  // paints with, and the menu its real captions.
+  SeedLevelAlertRules;
+  UpdateApiInformation;
+
+  SetAgoText(RS_INIT_FETCH, '');
+
+  {$ifdef TrndiExt}
+  // Extensions capture the api pointer (TJSfuncs), so they load only once the
+  // backend that serves the session is settled. Queued rather than called:
+  // this runs inside the worker's Synchronize and the permission prompts
+  // LoadExtensions can raise are modal. The first fetchCallback comes from
+  // the same worker's later ApplyResult, well after this queued call ran.
+  Application.QueueAsyncCall(@DeferredLoadExtensions, 0);
+  {$endif}
+end;
+
+procedure TfBG.DeferredLoadExtensions({%H-}Data: PtrInt);
+begin
+  if FShuttingDown then
+    Exit;
+  {$ifdef TrndiExt}
+  LoadExtensions;
+  {$endif}
+end;
+
+// Queued from ApplyConnectResult on the main thread. This is the old
+// FormCreate connect loop, run once per failure with the window visible: a
+// failed Connect at boot (e.g. an expired CareLink token) lands the user in
+// Settings; new backend settings are retried in place, closing Settings
+// unchanged quits.
+procedure TfBG.DeferredBootConnectFailure({%H-}Data: PtrInt);
+var
+  prevSetup: string;
+begin
+  if FShuttingDown then
+    Exit;
+
+  // The worker has left Synchronize by now (ApplyConnectResult queued this
+  // call and returned); reap it so the api it used can be replaced below.
+  if Assigned(FGlucoseFetchThread) then
+  begin
+    SafeThreadJoin(FGlucoseFetchThread);
+    FreeAndNil(FGlucoseFetchThread);
+  end;
+
+  ShowMessage(FBootConnectError);
+
+  prevSetup := native.GetSetting('remote.type') + '|' + native.GetSetting('remote.target') +
+    '|' + native.GetSetting('remote.creds');
+  firstboot := true; // Settings saves silently and skips the save prompt
+  miSettings.Click;
+  firstboot := false;
+
+  if native.GetSetting('remote.type') + '|' + native.GetSetting('remote.target') +
+    '|' + native.GetSetting('remote.creds') = prevSetup then
+  begin
+    firstboot := true; // Ensure quit doesn't ask for confirmation
+    Close;
+    Exit;
+  end;
+
+  FreeAndNil(api);
+  if not InitializeAPI then
+  begin
+    EnterSetupScreen;
+    Exit;
+  end;
+  api.APIEmitter := @APIReceiver;
+  api.OnCredentialsChanged := @APICredentialsChanged;
+  ArmBootFetch(100);
+end;
+
+procedure TfBG.EnterSetupScreen;
+begin
+  firstboot := true;
+  if Assigned(fSplash) then
+  begin
+    fSplash.Hide;
+    FreeAndNil(fSplash);
+  end;
+  // Reached after boot too (backend replaced with one that cannot be
+  // created): the spinner would otherwise overwrite the Setup caption.
+  FBootFetchPending := false;
+  FBootConnectPending := false;
+  if Assigned(tBootSpinner) then
+    StopBootSpinner;
+  tMain.Enabled := false;
+  lArrow.Caption := '';
+  lVal.Caption := RS_SETUP;
+  lVal.Cursor := crHandPoint;
+  bSettings.Show;
+  LayoutSetupScreen;
 end;
 
 // Web Server Methods

--- a/inc/umain_init.inc
+++ b/inc/umain_init.inc
@@ -779,8 +779,8 @@ begin
   InitializePlatformMenus;
   {$endif}
   {$ifdef X_LINUXBSD}
-  if TrndiNative.HasGlobalMenu then
-    InitializePlatformMenus;
+  // InitializePlatformMenus gates on native.HasGlobalMenu itself.
+  InitializePlatformMenus;
   {$endif}
 
   if ssShift in GetKeyShiftState then

--- a/inc/umain_timers.inc
+++ b/inc/umain_timers.inc
@@ -951,6 +951,9 @@ begin
   if FShuttingDown then
     Exit;
   TrndiDLog('OnSystemWake: OS reported resume-from-sleep — forcing refresh');
+  // The desktop theme may have flipped while asleep (scheduled dark mode);
+  // the next setColorMode should ask again rather than trust the cache.
+  TrndiNative.InvalidateThemeCache;
   FForceRefresh := true;
   if firstboot then
     Exit;

--- a/inc/umain_timers.inc
+++ b/inc/umain_timers.inc
@@ -517,6 +517,10 @@ end;
 
 procedure TfBG.UpdateApiInformation;
 begin
+  // The thresholds are initCGMCore's placeholders until the boot worker has
+  // connected; ApplyConnectedApi calls back in once they are real.
+  if FBootConnectPending then
+    Exit;
   miHi.Caption := Format(RS_HI_LEVEL, [api.cgmHi * BG_CONVERTIONS[un][mgdl]]);
   miLo.Caption := Format(RS_LO_LEVEL, [api.cgmLo * BG_CONVERTIONS[un][mgdl]]);
 
@@ -1058,12 +1062,41 @@ end;
 // that starts its work (Sleep / network I/O) before the main thread has had
 // a chance to enter Application.Run — symptom: form in taskbar, never drawn.
 procedure TfBG.tBootFetchTimer(Sender: TObject);
+const
+  // 50 ms ticks; RequestAsyncFetch only declines for the few ms the previous
+  // worker needs to unwind after its Synchronize, so this is never reached
+  // unless the api is gone for good.
+  MAX_BOOT_FETCH_TICKS = 40;
 begin
-  RetireOneShotTimer(tBootFetch);
+  if FShuttingDown then
+  begin
+    RetireOneShotTimer(tBootFetch);
+    Exit;
+  end;
+  Inc(FBootFetchAttempts);
   // Route through updateReading like every other fetch trigger, so the boot
   // fetch gets the same wrapper semantics (native.start, the refresh caption,
-  // force-flag bookkeeping) instead of a bespoke direct call.
-  updateReading(true);
+  // force-flag bookkeeping) instead of a bespoke direct call. Keep ticking
+  // until a worker was actually started: the connect-failure retry re-arms
+  // this timer right after the failed worker was reaped, and the request is
+  // dropped while that worker is still tearing down.
+  if updateReading(true) or (FBootFetchAttempts >= MAX_BOOT_FETCH_TICKS) then
+    RetireOneShotTimer(tBootFetch);
+end;
+
+procedure TfBG.ArmBootFetch(const DelayMs: integer);
+begin
+  FBootFetchAttempts := 0;
+  // RetireOneShotTimer drops the reference without freeing (the form owns
+  // the object), so a re-arm after a retired timer creates a fresh one.
+  if not Assigned(tBootFetch) then
+  begin
+    tBootFetch := TTimer.Create(Self);
+    tBootFetch.OnTimer := @tBootFetchTimer;
+  end;
+  tBootFetch.Enabled := false;
+  tBootFetch.Interval := DelayMs;
+  tBootFetch.Enabled := true;
 end;
 
 // Animates the braille-spinner glyph in lVal while the very first fetch is

--- a/units/forms/umain.pp
+++ b/units/forms/umain.pp
@@ -186,16 +186,24 @@ private
   FOwner: TfBG;
   FBoot: boolean;
   FForce: boolean;
+  FConnectFirst: boolean; // Run api.Connect before the fetch (boot only)
+  FConnectOK: boolean;
+  FConnectErr: string;
+  FAbortFetch: boolean;   // Set on the main thread inside ApplyConnectResult;
+                          // api may be replaced afterwards, so the worker
+                          // must unwind without touching it again
   FResults: BGResults;
   FErrorMsg: string;
   {$ifdef DEBUG}
   FDiag: string;
   {$endif}
+  procedure ApplyConnectResult;
   procedure ApplyResult;
 protected
   procedure Execute; override;
 public
-  constructor Create(AOwner: TfBG; Boot: boolean; Force: boolean);
+  constructor Create(AOwner: TfBG; Boot: boolean; Force: boolean;
+    ConnectFirst: boolean = false);
 end;
 
 {**
@@ -678,6 +686,15 @@ private
   FGlucoseFetchThread: TGlucoseFetchThread;
   FBootFetchPending: boolean; // True while the splash-time first fetch is in
                               // flight; gates the boot-failure warning panel.
+  FBootConnectPending: boolean; // True from FormCreate until api.Connect has
+                                // succeeded on the boot worker; only the boot
+                                // fetch may use the backend until then.
+  FBootConnectError: string;    // Connect failure text handed from the worker
+                                // to DeferredBootConnectFailure.
+  FBootFetchAttempts: integer;  // tBootFetch ticks since the last ArmBootFetch
+  FSafeModeRequested: boolean;  // Ctrl held at launch: skip extension loading.
+  FPendingApiMsg: string;       // APIReceiver marshal slot for a worker-thread
+  FPendingApiMsgType: TrndiAPIMsg; // emit, delivered via Synchronize.
   FHistoryFetchThread: THistoryFetchThread;
   // Shared guard: true while EITHER a TGlucoseFetchThread or
   // THistoryFetchThread is interacting with the TrndiAPI. Both backends
@@ -828,6 +845,28 @@ private
   procedure tBootFetchTimer(Sender: TObject);
   procedure tBootSpinnerTimer(Sender: TObject);
   procedure StopBootSpinner;
+  {** (Re)arm the one-shot boot-fetch timer. FormCreate arms it last; the
+      connect-failure path arms it again after the backend was replaced. }
+  procedure ArmBootFetch(const DelayMs: integer);
+  {** Runs on the main thread, from the boot worker's Synchronize, once
+      api.Connect succeeded: settles the thresholds (wizard fallback, user
+      overrides), seeds the level alerts and queues extension loading. Must
+      complete before the worker's getReadings, which stamps levels. }
+  procedure ApplyConnectedApi;
+  {** Queued by ApplyConnectResult when the boot Connect failed: error dialog,
+      Settings, then retry with the new backend or quit if nothing changed.
+      Runs after the worker has left Synchronize so a quit from the dialog
+      does not wait on a parked thread. }
+  procedure DeferredBootConnectFailure(Data: PtrInt);
+  {** Queued by ApplyConnectedApi: extension loading raises modal permission
+      prompts, which must not run while the worker is parked in Synchronize. }
+  procedure DeferredLoadExtensions(Data: PtrInt);
+  {** Drop to the "Setup" screen: no usable backend, the reading area becomes
+      a button into Settings. Safe both during FormCreate and afterwards. }
+  procedure EnterSetupScreen;
+  {** Main-thread half of APIReceiver: shows/logs the message. }
+  procedure DeliverApiMessage(const msg: string; etype: TrndiAPIMsg);
+  procedure DeliverPendingApiMessage;
   {** Disable a fired one-shot timer and drop the reference to it, without
       freeing it. Every caller runs from inside the timer's own OnTimer, where
       a free would tear down the widgetset timer whose callback is still on the

--- a/units/trndi/trndi.native.base.pp
+++ b/units/trndi/trndi.native.base.pp
@@ -323,6 +323,10 @@ class var touchOverride: TTrndiBool;
     // Theme/Env
     {** Determine if the OS/theme uses a dark appearance. Platforms override. }
   class function isDarkMode: boolean; virtual;
+    {** Forget any cached theme probe so the next @link(isDarkMode) asks the
+        desktop again. Called on resume-from-sleep; a no-op on platforms whose
+        detection is cheap enough not to cache. }
+  class procedure InvalidateThemeCache; virtual;
     {** Ask the platform to apply a dark appearance. @param(winHandle) is the
         native window handle for platforms that theme per-window (Windows
         DWM); 0 targets nothing/the app default — the same PtrUInt
@@ -1945,6 +1949,15 @@ end;
 class function TTrndiNativeBase.isDarkMode: boolean;
 begin
   Result := DefaultIsDarkMode;
+end;
+
+{------------------------------------------------------------------------------
+  InvalidateThemeCache (class, virtual)
+  -------------------------------------
+  Base: nothing is cached, so nothing to drop.
+ ------------------------------------------------------------------------------}
+class procedure TTrndiNativeBase.InvalidateThemeCache;
+begin
 end;
 
 {------------------------------------------------------------------------------

--- a/units/trndi/trndi.native.linux.pp
+++ b/units/trndi/trndi.native.linux.pp
@@ -243,6 +243,8 @@ public
     5) Fallback heuristic comparing clWindow vs clWindowText brightness.
   }
   class function isDarkMode: boolean; override;
+    {** Drops the cached @link(isDarkMode) answer so the next call re-probes. }
+  class procedure InvalidateThemeCache; override;
     {** Returns True if notify-send is available on this system. }
   class function isNotificationSystemAvailable: boolean; override;
     {** Identify notification backend: 'dbus' or 'gdbus' (the Qt6 bus paths),
@@ -527,6 +529,10 @@ end;
   the Qt tool is only a fallback, and its binary name varies by distro
   (plain `qdbus` does not exist on e.g. Fedora KDE, which ships `qdbus-qt6`).
  ------------------------------------------------------------------------------}
+var
+gGlobalMenuProbed: boolean = false;
+gGlobalMenuResult: boolean = false;
+
 class function TTrndiNativeLinux.HasGlobalMenu: boolean;
 const
   QDBUS_NAMES: array[0..4] of string =
@@ -550,14 +556,27 @@ var
       (Pos('org.kde.appmenu', lower) > 0);
   end;
 
+  // Every probe below is a subprocess with a multi-second timeout, and the
+  // answer cannot change for the lifetime of the process (the menu bar is
+  // built once from it). Startup used to pay the full chain twice.
+  function Remember(const v: boolean): boolean;
+  begin
+    gGlobalMenuResult := v;
+    gGlobalMenuProbed := true;
+    Result := v;
+  end;
+
 begin
+  if gGlobalMenuProbed then
+    Exit(gGlobalMenuResult);
+
   Result := False;
 
   toolPath := FindInPath('busctl');
   if toolPath <> '' then
     if RunAndCaptureSimpleWait(toolPath, ['--user', '--no-pager', '--acquired', 'list'],
       outS, exitCode, 7000) and (exitCode = 0) and HasRegistrar(outS) then
-      Exit(True);
+      Exit(Remember(True));
 
   toolPath := FindInPath('gdbus');
   if toolPath <> '' then
@@ -566,7 +585,7 @@ begin
       '--object-path', '/org/freedesktop/DBus',
       '--method', 'org.freedesktop.DBus.ListNames'],
       outS, exitCode, 7000) and (exitCode = 0) and HasRegistrar(outS) then
-      Exit(True);
+      Exit(Remember(True));
 
   for i := Low(QDBUS_NAMES) to High(QDBUS_NAMES) do
   begin
@@ -575,14 +594,14 @@ begin
       Continue;
     if RunAndCaptureSimpleWait(toolPath, [], outS, exitCode, 7000) and
       (exitCode = 0) and HasRegistrar(outS) then
-      Exit(True);
+      Exit(Remember(True));
   end;
 
   // GTK module hint: only match explicit appmenu-gtk module, not the generic 'appmenu' substring
   gtkMods := LowerCase(GetEnvironmentVariable('GTK_MODULES'));
   if gtkMods <> '' then
     if Pos('appmenu-gtk', gtkMods) > 0 then
-      Exit(True);
+      Exit(Remember(True));
 
   // Do NOT use KDE plasmoid presence as a global-menu indicator:
   // the plasmoid may be visible for display purposes without a desktop
@@ -591,7 +610,7 @@ begin
   // Do NOT check for appmenu helper tools on PATH; their presence does not
   // guarantee a working global menu bar integration.
 
-  Result := False;
+  Result := Remember(False);
 end;
 
 // (CurlWriteCallback_Linux moved to trndi.native.request.curl as
@@ -1126,7 +1145,45 @@ end;
   Desktop-aware detection: portal (gdbus), KDE (kreadconfig6/5), GNOME
   (gsettings), GTK_THEME, or fallback luminance heuristic.
  ------------------------------------------------------------------------------}
+var
+gDarkModeCached: boolean = false;
+gDarkModeCheckedAt: QWord = 0;
+gDarkModeValid: boolean = false;
+
+function DetectDarkModeUncached: boolean; forward;
+
 class function TTrndiNativeLinux.isDarkMode: boolean;
+const
+  // Every probe below is a bus call or a subprocess with a multi-second
+  // timeout. The value is read by every TrndiNative constructor (four of
+  // them at boot), by setColorMode on every reading and by each alert
+  // dialog, so it is cached like ShouldSuppressTrayIcon. There is no theme
+  // change signal on Linux; a switch is picked up within the TTL, which is
+  // sooner than the once-per-reading cadence that used to notice it.
+  DARK_MODE_TTL_MS = 30000;
+begin
+  if gDarkModeValid and
+    (GetTickCount64 - gDarkModeCheckedAt < DARK_MODE_TTL_MS) then
+    Exit(gDarkModeCached);
+
+  Result := DetectDarkModeUncached;
+
+  gDarkModeCached := Result;
+  gDarkModeCheckedAt := GetTickCount64;
+  gDarkModeValid := true;
+end;
+
+class procedure TTrndiNativeLinux.InvalidateThemeCache;
+begin
+  gDarkModeValid := false;
+end;
+
+{------------------------------------------------------------------------------
+  DetectDarkModeUncached
+  ----------------------
+  The actual probe chain behind isDarkMode.
+ ------------------------------------------------------------------------------}
+function DetectDarkModeUncached: boolean;
 var
   v: boolean;
   envGtkTheme: string;


### PR DESCRIPTION
FormCreate used to call api.Connect synchronously before the window was
shown: one HTTPS round-trip for Nightscout, five or more for CareLink, and
on a slow network nothing but a taskbar icon until it returned. The boot
worker (TGlucoseFetchThread with ConnectFirst) now connects, hands the
result to the main thread via Synchronize, and only then fetches, because
getReadings stamps levels with the thresholds Connect fills in.

ApplyConnectedApi carries the threshold fix-ups (wizard fallback, user
overrides, alert seeding) that followed Connect, and queues extension
loading — TJSfuncs captures the api pointer, so extensions wait for the
backend that will serve the session. The old "error, Settings, retry or
quit" loop moved to DeferredBootConnectFailure, queued rather than run
inside Synchronize so a quit from that dialog never waits on a parked
worker. Fetches other than the boot one are declined while the connect is
pending, UpdateApiInformation skips the placeholder thresholds, and
APIReceiver marshals worker-thread emits (CareLink's patient notice) to
the main thread instead of touching the LCL from the worker.

Extension safe mode samples Ctrl at launch (FSafeModeRequested) since the
load now happens seconds later. The two MAX_RESULT scalings collapse into
InitializeAPI; neither depended on Connect.
