### PR TITLE
Detect media players on first alert instead of at boot

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -280,7 +280,9 @@ always fits.
 Can be configured in settings to:
 - Play a sound when you go high or low
 - Show desktop notifications
-- Pause your music (Spotify/Deezer) to get your attention
+- Pause your music (Spotify/Deezer) to get your attention. The player is
+  looked for when an alert fires, so it does not need to be running when
+  Trndi starts.
 
 ### Low Insulin Warnings
 If your data source reports the reservoir (Tandem Source, CareLink, or a

--- a/inc/umain_async.inc
+++ b/inc/umain_async.inc
@@ -369,13 +369,17 @@ end;
   UI stays responsive while the network round-trip is in flight.
  ------------------------------------------------------------------------------}
 constructor TGlucoseFetchThread.Create(AOwner: TfBG; Boot: boolean;
-Force: boolean);
+Force: boolean; ConnectFirst: boolean);
 begin
   inherited Create(true);
   FreeOnTerminate := false;
   FOwner := AOwner;
   FBoot := Boot;
   FForce := Force;
+  FConnectFirst := ConnectFirst;
+  FConnectOK := false;
+  FConnectErr := '';
+  FAbortFetch := false;
   FErrorMsg := '';
   SetLength(FResults, 0);
   Start;
@@ -391,6 +395,34 @@ begin
     try
       if not Assigned(api) then
         Exit;
+
+      // Boot: api.Connect used to run synchronously inside FormCreate, before
+      // the window existed — a slow network or CareLink's multi-step login
+      // meant an icon in the taskbar and nothing else. It runs here now.
+      // The thresholds it fills in are needed before getReadings stamps
+      // levels, so the main thread applies them (ApplyConnectResult) between
+      // the two calls.
+      if FConnectFirst then
+      begin
+        try
+          FConnectOK := api.Connect;
+          if not FConnectOK then
+            FConnectErr := api.errormsg;
+        except
+          on E: Exception do
+          begin
+            FConnectOK := false;
+            FConnectErr := E.ClassName + ': ' + E.Message;
+          end;
+        end;
+        if Terminated then
+          Exit;
+        Synchronize(@ApplyConnectResult);
+        // The failure path frees and replaces api once this worker has
+        // unwound; nothing below may touch it when FAbortFetch is set.
+        if FAbortFetch or (not FConnectOK) or Terminated then
+          Exit;
+      end;
 
       {$ifdef DEBUG}
       FResults := api.getReadings(MAX_MIN, MAX_RESULT, '', FDiag, FForce);
@@ -417,9 +449,45 @@ begin
       end;
     end;
   finally
-    if not Terminated then
+    if (not Terminated) and (not FAbortFetch) then
       Synchronize(@ApplyResult);
   end;
+end;
+
+// Main thread, between the worker's Connect and its getReadings.
+procedure TGlucoseFetchThread.ApplyConnectResult;
+begin
+  if not Assigned(FOwner) then
+  begin
+    FAbortFetch := true;
+    Exit;
+  end;
+
+  if FOwner.FShuttingDown then
+  begin
+    FAbortFetch := true;
+    FOwner.FApiCallInFlight := false;
+    if FBoot then
+      FOwner.FBootFetchPending := false;
+    Exit;
+  end;
+
+  if FConnectOK then
+  begin
+    FOwner.FBootConnectPending := false;
+    FOwner.ApplyConnectedApi;
+    Exit;
+  end;
+
+  // Failure. Release the api gate here, but run the dialogs from the message
+  // loop rather than from inside this Synchronize: they are modal, and a
+  // worker parked in Synchronize for the length of a Settings session would
+  // stall a quit from that dialog until the fetch-shutdown timeout detached
+  // it. The boot spinner keeps running; the retry re-enters the boot path.
+  FAbortFetch := true;
+  FOwner.FApiCallInFlight := false;
+  FOwner.FBootConnectError := FConnectErr;
+  Application.QueueAsyncCall(@FOwner.DeferredBootConnectFailure, 0);
 end;
 
 procedure TGlucoseFetchThread.ApplyResult;

--- a/inc/umain_ext.inc
+++ b/inc/umain_ext.inc
@@ -363,8 +363,12 @@ begin
     fSplash.incProgress(79, 'Initializing extensions backend..');
 
   // Safe mode: holding Ctrl during startup skips all extension loading.
-  if ssCtrl in GetKeyShiftState then
+  // Boot samples the key at the top of FormCreate (FSafeModeRequested): the
+  // load itself now runs seconds later, after the backend connected, and the
+  // user has long let go by then. A live Ctrl still counts for manual reloads.
+  if FSafeModeRequested or (ssCtrl in GetKeyShiftState) then
   begin
+    FSafeModeRequested := false;
     SlickeHTMLMsg(sdsAuto, RS_SAFEMODE, RS_SAFEMODE_DESC, [mbOK], uxmtInformation, uxscLarge);
     exts.Free;
     Exit;

--- a/inc/umain_ext.inc
+++ b/inc/umain_ext.inc
@@ -138,7 +138,7 @@ begin
   result := '';
   exists := false;
 
-  if not Assigned(TTrndiExtEngine.Instance) then Exit;
+  if not Assigned(TTrndiExtEngine.Existing) then Exit;
 
   n := TTrndiExtEngine.Instance.ExtensionCount;
   for i := 0 to n - 1 do
@@ -314,14 +314,16 @@ procedure TfBG.ReloadExtensions(Sender: TObject);
 var
   engine: TTrndiExtEngine;
 begin
-  // Instance() returns nil during shutdown (IsExtShuttingDown). If we got
+  // Existing is nil during shutdown (IsExtShuttingDown). If we got
   // re-entered via ProcessMessages while UnloadExtensions is draining, treat
   // it as "nothing to do" — the in-flight reload will complete and the user
-  // can retry. Don't fall through to LoadExtensions with a nil engine.
-  engine := TTrndiExtEngine.Instance;
-  if engine = nil then
+  // can retry. It is also nil when boot found no scripts and never built the
+  // engine; LoadExtensions then builds it on demand for the first .js.
+  if IsExtShuttingDown then
     Exit;
-  engine.UnloadExtensions;
+  engine := TTrndiExtEngine.Existing;
+  if engine <> nil then
+    engine.UnloadExtensions;
   LoadExtensions;
 end;
 
@@ -341,17 +343,34 @@ var
   extInfo: PExtContextInfo;
   nativeRef: TrndiNative;
 begin
+  extdir := GetAppConfigDirUTF8(false, true) + 'extensions' + DirectorySeparator;
+  ForceDirectoriesUTF8(extdir);
+  exts := FindAllFiles(extdir, '*.js', false);
+
+  // No scripts, no engine. TTrndiExtEngine.Instance constructs the QuickJS
+  // runtime on first touch — with its permanent 50 ms job-pump timer, the
+  // shim scripts and one more TrndiNative — so the directory is looked at
+  // before the engine is. Readers elsewhere go through Existing for the same
+  // reason; a later Reload builds the engine once a script has appeared.
+  if exts.Count = 0 then
+  begin
+    TrndiDLog('LoadExtensions: no extensions installed; engine not started');
+    exts.Free;
+    Exit;
+  end;
+
   // Bail if the engine isn't available (shutdown in progress). Without this,
   // the loop below would invoke NewExtensionContext on a nil Self and crash
   // at the first field access (`if FRuntime = nil then Exit;`).
   if TTrndiExtEngine.Instance = nil then
+  begin
+    exts.Free;
     Exit;
+  end;
   if not Assigned(jsFuncs) then
     jsFuncs := TJSfuncs.Create(api);
+  TrndiDLog(Format('LoadExtensions: %d script(s) in %s', [exts.Count, extdir]));
 
-  extdir := GetAppConfigDirUTF8(false, true) + 'extensions' + DirectorySeparator;
-  ForceDirectoriesUTF8(extdir);
-  exts := FindAllFiles(extdir, '*.js', false);
   // Ids are case-folded file names, so Test.js and test.js collide (possible
   // on case-sensitive file systems) and would share settings and grant keys.
   // Sort so "first file wins" is deterministic, not directory-scan order;
@@ -441,7 +460,7 @@ begin
       // GrantPermissionsFor above shows a modal prompt that pumps messages;
       // the engine may have been released in the meantime (FormClose path).
       // Bail rather than dereference nil inside NewExtensionContext.
-      if TTrndiExtEngine.Instance = nil then
+      if TTrndiExtEngine.Existing = nil then
         Break;
 
       // Create the per-extension JSContext with engine-internal baselines provisioned.

--- a/inc/umain_glucose.inc
+++ b/inc/umain_glucose.inc
@@ -1583,6 +1583,16 @@ begin
   if api = nil then
     Exit;
 
+  // Until the boot worker's Connect has succeeded only the boot fetch itself
+  // may use the backend: a periodic tick landing while the connect-failure
+  // Settings dialog is up would otherwise fetch against a backend that never
+  // connected, or against one that is about to be replaced.
+  if FBootConnectPending and (not Boot) then
+  begin
+    TrndiDLog('RequestAsyncFetch: dropped — boot connect still pending');
+    Exit;
+  end;
+
   if FApiCallInFlight then
   begin
     TrndiDLog('RequestAsyncFetch: dropped — api call already in flight');
@@ -1631,7 +1641,8 @@ begin
   TrndiDLog('RequestAsyncFetch: starting worker (boot=' +
     BoolToStr(Boot, true) + ' force=' + BoolToStr(Force, true) + ')');
 
-  FGlucoseFetchThread := TGlucoseFetchThread.Create(Self, Boot, Force);
+  FGlucoseFetchThread := TGlucoseFetchThread.Create(Self, Boot, Force,
+    Boot and FBootConnectPending);
   Result := true;
 end;
 

--- a/inc/umain_glucose.inc
+++ b/inc/umain_glucose.inc
@@ -2636,7 +2636,9 @@ begin
     Exit;
   if not assigned(mediacontroller) then
     Exit;
-  if not mediacontroller.IsInitialized then
+  // Detect the player now rather than at boot; this also finds a player that
+  // was started after Trndi, which the boot-time probe never could.
+  if not mediacontroller.EnsureInitialized then
     Exit;
 
   case act of

--- a/inc/umain_helpers.inc
+++ b/inc/umain_helpers.inc
@@ -50,6 +50,33 @@ end;
 
 procedure TfBG.APIReceiver(const msg: string; etype: TrndiAPIMsg);
 begin
+  // Backends emit from whichever thread runs them — Connect and getReadings
+  // both live on the fetch worker — and alert/notice end in LCL calls. Hand
+  // those to the main thread and let the worker wait. FApiCallInFlight keeps
+  // one worker on the api at a time, so a single marshal slot suffices. A
+  // worker detached at shutdown must not block on a main loop that is gone.
+  if GetCurrentThreadId <> MainThreadID then
+  begin
+    if FShuttingDown then
+    begin
+      TrndiDLog(msg);
+      Exit;
+    end;
+    FPendingApiMsg := msg;
+    FPendingApiMsgType := etype;
+    TThread.Synchronize(TThread.CurrentThread, @DeliverPendingApiMessage);
+    Exit;
+  end;
+  DeliverApiMessage(msg, etype);
+end;
+
+procedure TfBG.DeliverPendingApiMessage;
+begin
+  DeliverApiMessage(FPendingApiMsg, FPendingApiMsgType);
+end;
+
+procedure TfBG.DeliverApiMessage(const msg: string; etype: TrndiAPIMsg);
+begin
   case etype of
   TrndiAPIMsg.alert:
     SlickeMessage('API Alert', msg, uxmtWarning);

--- a/inc/umain_init.inc
+++ b/inc/umain_init.inc
@@ -528,15 +528,22 @@ begin
     end;
   end;
 
-  // Scale MAX_RESULT to the API's reporting frequency so all dot slots can be
+  // Ensure MAX_MIN and MAX_RESULT cover the full dot window, then scale
+  // MAX_RESULT to the API's reporting frequency so all dot slots can be
   // filled even for backends that upload more often than every 5 minutes.
-  // Formula: 25 × ceil(INTERVAL_MINUTES / reportingInterval)
+  // Formula: max(25, ACTIVE_DOTS) × ceil(INTERVAL_MINUTES / reportingInterval)
   //   5-min backend → 25 × 1 = 25
   //   1-min backend → 25 × 5 = 125
+  // getReportingInterval is a backend constant, so this needs no Connect.
   if Assigned(api) then
+  begin
+    if MAX_MIN < ACTIVE_DOTS * INTERVAL_MINUTES + 10 then
+      MAX_MIN := ACTIVE_DOTS * INTERVAL_MINUTES + 10;
     MAX_RESULT := Max(MAX_RESULT,
-      25 * Max(1, (INTERVAL_MINUTES + api.getReportingInterval - 1)
-                   div api.getReportingInterval));
+      Max(25, ACTIVE_DOTS) *
+      Max(1, (INTERVAL_MINUTES + api.getReportingInterval - 1)
+        div api.getReportingInterval));
+  end;
 end;
 
 {$ifdef X_LINUXBSD}
@@ -649,21 +656,8 @@ end;
 
 // Initialize the TrendDots array in FormCreate
 procedure TfBG.FormCreate({%H-}Sender: TObject);
-procedure haltBoot;
-  begin
-    firstboot := true;
-    fSplash.Hide;
-    FreeAndNil(fSplash);
-    tMain.Enabled := false;
-    lArrow.Caption := '';
-    lVal.Caption := RS_SETUP;
-    lVal.Cursor := crHandPoint;
-    bSettings.Show;
-    LayoutSetupScreen;
-  end;
-
 var
-  guifontName, txtfontName, apiTarget, prevSetup: string;
+  guifontName, txtfontName, apiTarget: string;
   fil, englishOnce: boolean;
   userlocale: TFormatSettings;
   minutesStr: string;
@@ -675,6 +669,9 @@ var
 begin
   TrndiDLog(Format(#10'=== Trndi started at %s ===', [DateTimeToStr(Now)]));
   firstboot := false;
+  // Extension safe mode is decided by the key state at launch, not at the
+  // (now deferred) moment the extensions load.
+  FSafeModeRequested := ssCtrl in GetKeyShiftState;
 
   // Assigned here rather than in the LFM: it pairs with the wsMinimized guard
   // in tResizeTimer, which is the only reason the event is wanted at all.
@@ -923,7 +920,7 @@ begin
     Application.ProcessMessages;
     if not InitializeAPI then
     begin
-      haltBoot;
+      EnterSetupScreen;
       Exit;
     end;
 
@@ -955,56 +952,16 @@ begin
 
     api.APIEmitter := @APIReceiver;
     api.OnCredentialsChanged := @APICredentialsChanged;
-    // A failed Connect at boot (e.g. an expired CareLink token) lands the
-    // user directly in Settings; the main window is never shown. New backend
-    // settings are retried in place, closing Settings unchanged quits.
-    while not api.Connect do
-    begin
-      fSplash.Hide;
-      ShowMessage(api.ErrorMsg);
-
-      prevSetup := GetSetting('remote.type') + '|' + GetSetting('remote.target') +
-        '|' + GetSetting('remote.creds');
-      firstboot := true; // Settings saves silently and leaves fBG hidden
-      miSettings.Click;
-      firstboot := false;
-
-      if GetSetting('remote.type') + '|' + GetSetting('remote.target') +
-        '|' + GetSetting('remote.creds') = prevSetup then
-      begin
-        firstboot := true; // Ensure quit doesn't ask for confirmation
-        FCloseAfterFormCreate := true;
-        Application.ShowMainForm := false;
-        Application.Terminate;
-        FreeAndNil(fSplash);
-        Exit;
-      end;
-
-      FreeAndNil(api);
-      if not InitializeAPI then
-      begin
-        haltBoot;
-        Exit;
-      end;
-      api.APIEmitter := @APIReceiver;
-      api.OnCredentialsChanged := @APICredentialsChanged;
-      fSplash.Show;
-    end;
+    // api.Connect runs on the boot worker (TGlucoseFetchThread with
+    // ConnectFirst), so the window is up and painting while the backend
+    // answers. ApplyConnectedApi finishes the threshold-dependent setup once
+    // it succeeds; DeferredBootConnectFailure runs the "error, Settings,
+    // retry or quit" flow when it does not.
+    FBootConnectPending := true;
 
     fSplash.incProgress(70, RS_INIT_UX);
     // UI preferences
     DOT_ADJUST := GetFloatSetting('ux.dot_adjust', 0);
-
-    // Ensure MAX_MIN and MAX_RESULT cover the full dot window.
-    // ACTIVE_DOTS was read before CreateTrendDots; the API-based MAX_RESULT
-    // scaling earlier used a default dot count — bump it for higher counts.
-    // MAX_RESULT is a reading count; mirror InitializeAPI's reporting-interval
-    // scaling but with ACTIVE_DOTS as the base.
-    if MAX_MIN < ACTIVE_DOTS * INTERVAL_MINUTES + 10 then
-      MAX_MIN := ACTIVE_DOTS * INTERVAL_MINUTES + 10;
-    MAX_RESULT := Max(MAX_RESULT,
-      ACTIVE_DOTS * Max(1, (INTERVAL_MINUTES + api.getReportingInterval - 1)
-                   div api.getReportingInterval));
 
     DIFF_ALIGN := native.GetAlignmentSetting('ux.labels.ldiff.alignment', taCenter);
 
@@ -1014,31 +971,8 @@ begin
     PaintRange := GetBoolSetting('ux.paint_range', true);
     PaintRangeLines := GetBoolSetting('ux.paint_range_lines', false);
     PaintRangeCGMRange := GetBoolSetting('ux.paint_range_cgmrange', false);
-    // Extensions
-    {$ifdef TrndiExt}
-    fSplash.incProgress(80, RS_SPLASH_LOADING_INIT);
-    LoadExtensions;
-    {$endif}
-
-    // Apply wizard-suggested thresholds for APIs that don't supply their own
-    // (cgmHi stays at initCGMCore's sentinel 401 when the API never set it)
-    if api.cgmHi = 401 then
-    begin
-      api.cgmHi := GetIntSetting('wizard.hi', api.cgmHi);
-      api.cgmLo := GetIntSetting('wizard.lo', api.cgmLo);
-    end;
-
-    fSplash.incProgress(85, RS_INIT_CUSTOM_OVERRIDES);
-    // Override settings - always apply if set, regardless of checkbox state
-    // This allows extensions and manual config edits to work
-    api.cgmLo := GetIntSetting('override.lo', api.cgmLo);
-    api.cgmHi := GetIntSetting('override.hi', api.cgmHi);
-    api.cgmRangeLo := GetIntSetting('override.rangelo', api.cgmRangeLo);
-    api.cgmRangeHi := GetIntSetting('override.rangehi', api.cgmRangeHi);
-
-    // Thresholds are final now - give the alert engine the same limits the UI
-    // paints with.
-    SeedLevelAlertRules;
+    // Extensions and the threshold fix-ups (wizard fallback, overrides, alert
+    // seeding) wait for the backend: see ApplyConnectedApi.
 
     PredictGlucoseReading := GetBoolSetting('predictions.enable', false);
     PredictShortMode := GetBoolSetting('predictions.short', false);
@@ -1095,7 +1029,7 @@ begin
   lArrow.Caption := '';
   lDiff.Caption := '';
   lRef.Caption := '';
-  SetAgoText(RS_INIT_FETCH, '');
+  SetAgoText(RS_INIT_CONNECT, '');
   FTirBadge.Clear;
   if Assigned(pnOffReading) then
     pnOffReading.Visible := false;
@@ -1117,16 +1051,12 @@ begin
   // message loop run first guarantees the form is painted and interactive
   // before any threading machinery starts.
   //
-  // Note: Enabled stays false here. The explicit Application.ProcessMessages
-  // further down (and any implicit pumping from fSplash.FadeOutAndClose /
-  // Self.Show)
-  // would otherwise dispatch this 50 ms WM_TIMER while FormCreate is still
-  // mid-setup. Arming happens at the very end of FormCreate.
+  // Note: the timer is not created here. The explicit
+  // Application.ProcessMessages further down (and any implicit pumping from
+  // fSplash.FadeOutAndClose / Self.Show) would otherwise dispatch its 50 ms
+  // WM_TIMER while FormCreate is still mid-setup. ArmBootFetch runs at the
+  // very end of FormCreate.
   FBootFetchPending := true;
-  tBootFetch := TTimer.Create(Self);
-  tBootFetch.Interval := 50;
-  tBootFetch.OnTimer := @tBootFetchTimer;
-  tBootFetch.Enabled := false;
 
   tBootSpinner := TTimer.Create(Self);
   tBootSpinner.Interval := 100;
@@ -1253,8 +1183,122 @@ begin
   // Application.ProcessMessages in FormCreate, so tBootFetchTimer cannot
   // fire until FormCreate returns and Application.Run starts pumping —
   // i.e. the form is fully constructed before any worker thread spawns.
-  if Assigned(tBootFetch) then
-    tBootFetch.Enabled := true;
+  ArmBootFetch(50);
+end;
+
+// Main thread, from the boot worker's Synchronize, after api.Connect
+// succeeded and before its getReadings. Everything here used to sit inline
+// in FormCreate behind the synchronous Connect.
+procedure TfBG.ApplyConnectedApi;
+begin
+  // Apply wizard-suggested thresholds for APIs that don't supply their own
+  // (cgmHi stays at initCGMCore's sentinel 401 when the API never set it)
+  if api.cgmHi = 401 then
+  begin
+    api.cgmHi := native.GetIntSetting('wizard.hi', api.cgmHi);
+    api.cgmLo := native.GetIntSetting('wizard.lo', api.cgmLo);
+  end;
+
+  // Override settings - always apply if set, regardless of checkbox state
+  // This allows extensions and manual config edits to work
+  api.cgmLo := native.GetIntSetting('override.lo', api.cgmLo);
+  api.cgmHi := native.GetIntSetting('override.hi', api.cgmHi);
+  api.cgmRangeLo := native.GetIntSetting('override.rangelo', api.cgmRangeLo);
+  api.cgmRangeHi := native.GetIntSetting('override.rangehi', api.cgmRangeHi);
+
+  // Thresholds are final now - give the alert engine the same limits the UI
+  // paints with, and the menu its real captions.
+  SeedLevelAlertRules;
+  UpdateApiInformation;
+
+  SetAgoText(RS_INIT_FETCH, '');
+
+  {$ifdef TrndiExt}
+  // Extensions capture the api pointer (TJSfuncs), so they load only once the
+  // backend that serves the session is settled. Queued rather than called:
+  // this runs inside the worker's Synchronize and the permission prompts
+  // LoadExtensions can raise are modal. The first fetchCallback comes from
+  // the same worker's later ApplyResult, well after this queued call ran.
+  Application.QueueAsyncCall(@DeferredLoadExtensions, 0);
+  {$endif}
+end;
+
+procedure TfBG.DeferredLoadExtensions({%H-}Data: PtrInt);
+begin
+  if FShuttingDown then
+    Exit;
+  {$ifdef TrndiExt}
+  LoadExtensions;
+  {$endif}
+end;
+
+// Queued from ApplyConnectResult on the main thread. This is the old
+// FormCreate connect loop, run once per failure with the window visible: a
+// failed Connect at boot (e.g. an expired CareLink token) lands the user in
+// Settings; new backend settings are retried in place, closing Settings
+// unchanged quits.
+procedure TfBG.DeferredBootConnectFailure({%H-}Data: PtrInt);
+var
+  prevSetup: string;
+begin
+  if FShuttingDown then
+    Exit;
+
+  // The worker has left Synchronize by now (ApplyConnectResult queued this
+  // call and returned); reap it so the api it used can be replaced below.
+  if Assigned(FGlucoseFetchThread) then
+  begin
+    SafeThreadJoin(FGlucoseFetchThread);
+    FreeAndNil(FGlucoseFetchThread);
+  end;
+
+  ShowMessage(FBootConnectError);
+
+  prevSetup := native.GetSetting('remote.type') + '|' + native.GetSetting('remote.target') +
+    '|' + native.GetSetting('remote.creds');
+  firstboot := true; // Settings saves silently and skips the save prompt
+  miSettings.Click;
+  firstboot := false;
+
+  if native.GetSetting('remote.type') + '|' + native.GetSetting('remote.target') +
+    '|' + native.GetSetting('remote.creds') = prevSetup then
+  begin
+    firstboot := true; // Ensure quit doesn't ask for confirmation
+    Close;
+    Exit;
+  end;
+
+  FreeAndNil(api);
+  if not InitializeAPI then
+  begin
+    EnterSetupScreen;
+    Exit;
+  end;
+  api.APIEmitter := @APIReceiver;
+  api.OnCredentialsChanged := @APICredentialsChanged;
+  ArmBootFetch(100);
+end;
+
+procedure TfBG.EnterSetupScreen;
+begin
+  firstboot := true;
+  if Assigned(fSplash) then
+  begin
+    fSplash.Hide;
+    FreeAndNil(fSplash);
+  end;
+  // Reached after boot too (backend replaced with one that cannot be
+  // created): the spinner would otherwise overwrite the Setup caption.
+  FBootFetchPending := false;
+  FBootConnectPending := false;
+  if Assigned(tBootSpinner) then
+    StopBootSpinner;
+  tMain.Enabled := false;
+  lArrow.Caption := '';
+  lVal.Caption := RS_SETUP;
+  lVal.Cursor := crHandPoint;
+  bSettings.Show;
+  LayoutSetupScreen;
 end;
 
 // Web Server Methods

--- a/inc/umain_init.inc
+++ b/inc/umain_init.inc
@@ -753,11 +753,13 @@ begin
   Application.ProcessMessages;
   Application.OnException := @AppExceptionHandler;
 
-  // Start media backend early
+  // The media backend is created here but initialised on first use
+  // (actOnMediaController): detection spawns one pgrep/tasklist per known
+  // player, and that used to sit on the boot path for a feature that only
+  // acts when an alert fires.
   if not native.GetBoolSetting('media.disabled', false) then begin
     fSplash.incProgress(10, RS_INIT_MEDIA);
     MediaController := TSystemMediaController.Create(Self);
-    MediaController.Initialize;
   end;
   Application.ProcessMessages;
 

--- a/inc/umain_init.inc
+++ b/inc/umain_init.inc
@@ -779,8 +779,8 @@ begin
   InitializePlatformMenus;
   {$endif}
   {$ifdef X_LINUXBSD}
-  if TrndiNative.HasGlobalMenu then
-    InitializePlatformMenus;
+  // InitializePlatformMenus gates on native.HasGlobalMenu itself.
+  InitializePlatformMenus;
   {$endif}
 
   if ssShift in GetKeyShiftState then

--- a/inc/umain_menu.inc
+++ b/inc/umain_menu.inc
@@ -323,6 +323,12 @@ end;
 procedure TfBG.miExtLogClick(Sender: TObject);
 begin
   {$ifdef TrndiExt}
+  // Reading Instance here would build the engine just to show an empty log.
+  if TTrndiExtEngine.Existing = nil then
+  begin
+    ShowMessage(RS_EXT_NONE_LOADED);
+    Exit;
+  end;
   with TTrndiExtEngine.Instance do
   begin
     ShowMessage(Output);

--- a/inc/umain_timers.inc
+++ b/inc/umain_timers.inc
@@ -951,6 +951,9 @@ begin
   if FShuttingDown then
     Exit;
   TrndiDLog('OnSystemWake: OS reported resume-from-sleep — forcing refresh');
+  // The desktop theme may have flipped while asleep (scheduled dark mode);
+  // the next setColorMode should ask again rather than trust the cache.
+  TrndiNative.InvalidateThemeCache;
   FForceRefresh := true;
   if firstboot then
     Exit;

--- a/inc/umain_timers.inc
+++ b/inc/umain_timers.inc
@@ -517,6 +517,10 @@ end;
 
 procedure TfBG.UpdateApiInformation;
 begin
+  // The thresholds are initCGMCore's placeholders until the boot worker has
+  // connected; ApplyConnectedApi calls back in once they are real.
+  if FBootConnectPending then
+    Exit;
   miHi.Caption := Format(RS_HI_LEVEL, [api.cgmHi * BG_CONVERTIONS[un][mgdl]]);
   miLo.Caption := Format(RS_LO_LEVEL, [api.cgmLo * BG_CONVERTIONS[un][mgdl]]);
 
@@ -1058,12 +1062,41 @@ end;
 // that starts its work (Sleep / network I/O) before the main thread has had
 // a chance to enter Application.Run — symptom: form in taskbar, never drawn.
 procedure TfBG.tBootFetchTimer(Sender: TObject);
+const
+  // 50 ms ticks; RequestAsyncFetch only declines for the few ms the previous
+  // worker needs to unwind after its Synchronize, so this is never reached
+  // unless the api is gone for good.
+  MAX_BOOT_FETCH_TICKS = 40;
 begin
-  RetireOneShotTimer(tBootFetch);
+  if FShuttingDown then
+  begin
+    RetireOneShotTimer(tBootFetch);
+    Exit;
+  end;
+  Inc(FBootFetchAttempts);
   // Route through updateReading like every other fetch trigger, so the boot
   // fetch gets the same wrapper semantics (native.start, the refresh caption,
-  // force-flag bookkeeping) instead of a bespoke direct call.
-  updateReading(true);
+  // force-flag bookkeeping) instead of a bespoke direct call. Keep ticking
+  // until a worker was actually started: the connect-failure retry re-arms
+  // this timer right after the failed worker was reaped, and the request is
+  // dropped while that worker is still tearing down.
+  if updateReading(true) or (FBootFetchAttempts >= MAX_BOOT_FETCH_TICKS) then
+    RetireOneShotTimer(tBootFetch);
+end;
+
+procedure TfBG.ArmBootFetch(const DelayMs: integer);
+begin
+  FBootFetchAttempts := 0;
+  // RetireOneShotTimer drops the reference without freeing (the form owns
+  // the object), so a re-arm after a retired timer creates a fresh one.
+  if not Assigned(tBootFetch) then
+  begin
+    tBootFetch := TTimer.Create(Self);
+    tBootFetch.OnTimer := @tBootFetchTimer;
+  end;
+  tBootFetch.Enabled := false;
+  tBootFetch.Interval := DelayMs;
+  tBootFetch.Enabled := true;
 end;
 
 // Animates the braille-spinner glyph in lVal while the very first fetch is

--- a/lang/Trndi.da.po
+++ b/lang/Trndi.da.po
@@ -1962,6 +1962,10 @@ msgstr "Din internetforbindelse virker!"
 msgid "The following extension file returned an error while loading: %s"
 msgstr "Følgende udvidelsesfile returnerede en fejl under indlæsning: %s"
 
+#: trndi.strings.rs_ext_none_loaded
+msgid "No extensions are loaded"
+msgstr "Ingen udvidelser er indlæst"
+
 #: trndi.strings.rs_ext_confirm
 msgctxt "trndi.strings.rs_ext_confirm"
 msgid "Extension Confirmation"

--- a/lang/Trndi.de.po
+++ b/lang/Trndi.de.po
@@ -1962,6 +1962,10 @@ msgstr "Ihre Internetverbindung funktioniert!"
 msgid "The following extension file returned an error while loading: %s"
 msgstr "Die folgende Erweiterungsdatei gab beim Laden einen Fehler zurück: %s"
 
+#: trndi.strings.rs_ext_none_loaded
+msgid "No extensions are loaded"
+msgstr "Es sind keine Erweiterungen geladen"
+
 #: trndi.strings.rs_ext_confirm
 msgctxt "trndi.strings.rs_ext_confirm"
 msgid "Extension Confirmation"

--- a/lang/Trndi.fr.po
+++ b/lang/Trndi.fr.po
@@ -2067,6 +2067,10 @@ msgstr "Votre connexion internet fonctionne !"
 msgid "The following extension file returned an error while loading: %s"
 msgstr "Le fichier d'extension suivant a renvoyé une erreur lors du chargement : %s"
 
+#: trndi.strings.rs_ext_none_loaded
+msgid "No extensions are loaded"
+msgstr "Aucune extension n'est chargée"
+
 #: trndi.strings.rs_ext_confirm
 msgctxt "trndi.strings.rs_ext_confirm"
 msgid "Extension Confirmation"

--- a/lang/Trndi.jm.po
+++ b/lang/Trndi.jm.po
@@ -2094,6 +2094,10 @@ msgstr "Din internetanslutning fungerar!"
 msgid "The following extension file returned an error while loading: %s"
 msgstr "Fôljande tilleggsfil returnerade ett fel ner den laddades: __PH9c3509d5-301d-47d0-a140-39da51a88054__"
 
+#: trndi.strings.rs_ext_none_loaded
+msgid "No extensions are loaded"
+msgstr ""
+
 #: trndi.strings.rs_ext_confirm
 #, fuzzy
 msgctxt "trndi.strings.rs_ext_confirm"

--- a/lang/Trndi.nb.po
+++ b/lang/Trndi.nb.po
@@ -1962,6 +1962,10 @@ msgstr "Internettforbindelsen din fungerer!"
 msgid "The following extension file returned an error while loading: %s"
 msgstr "Følgende utvidelsesfil returnerte en feil under lasting: %s"
 
+#: trndi.strings.rs_ext_none_loaded
+msgid "No extensions are loaded"
+msgstr "Ingen utvidelser er lastet"
+
 #: trndi.strings.rs_ext_confirm
 msgctxt "trndi.strings.rs_ext_confirm"
 msgid "Extension Confirmation"

--- a/lang/Trndi.pot
+++ b/lang/Trndi.pot
@@ -1947,6 +1947,10 @@ msgstr ""
 msgid "The following extension file returned an error while loading: %s"
 msgstr ""
 
+#: trndi.strings.rs_ext_none_loaded
+msgid "No extensions are loaded"
+msgstr ""
+
 #: trndi.strings.rs_ext_confirm
 msgctxt "trndi.strings.rs_ext_confirm"
 msgid "Extension Confirmation"

--- a/lang/Trndi.sv.po
+++ b/lang/Trndi.sv.po
@@ -2078,6 +2078,10 @@ msgstr "Din internetanslutning fungerar!"
 msgid "The following extension file returned an error while loading: %s"
 msgstr "Följande tilläggsfil returnerade ett fel när den laddades: %s"
 
+#: trndi.strings.rs_ext_none_loaded
+msgid "No extensions are loaded"
+msgstr "Inga tillägg är laddade"
+
 #: trndi.strings.rs_ext_confirm
 msgctxt "trndi.strings.rs_ext_confirm"
 msgid "Extension Confirmation"

--- a/units/forms/umain.pp
+++ b/units/forms/umain.pp
@@ -186,16 +186,24 @@ private
   FOwner: TfBG;
   FBoot: boolean;
   FForce: boolean;
+  FConnectFirst: boolean; // Run api.Connect before the fetch (boot only)
+  FConnectOK: boolean;
+  FConnectErr: string;
+  FAbortFetch: boolean;   // Set on the main thread inside ApplyConnectResult;
+                          // api may be replaced afterwards, so the worker
+                          // must unwind without touching it again
   FResults: BGResults;
   FErrorMsg: string;
   {$ifdef DEBUG}
   FDiag: string;
   {$endif}
+  procedure ApplyConnectResult;
   procedure ApplyResult;
 protected
   procedure Execute; override;
 public
-  constructor Create(AOwner: TfBG; Boot: boolean; Force: boolean);
+  constructor Create(AOwner: TfBG; Boot: boolean; Force: boolean;
+    ConnectFirst: boolean = false);
 end;
 
 {**
@@ -678,6 +686,15 @@ private
   FGlucoseFetchThread: TGlucoseFetchThread;
   FBootFetchPending: boolean; // True while the splash-time first fetch is in
                               // flight; gates the boot-failure warning panel.
+  FBootConnectPending: boolean; // True from FormCreate until api.Connect has
+                                // succeeded on the boot worker; only the boot
+                                // fetch may use the backend until then.
+  FBootConnectError: string;    // Connect failure text handed from the worker
+                                // to DeferredBootConnectFailure.
+  FBootFetchAttempts: integer;  // tBootFetch ticks since the last ArmBootFetch
+  FSafeModeRequested: boolean;  // Ctrl held at launch: skip extension loading.
+  FPendingApiMsg: string;       // APIReceiver marshal slot for a worker-thread
+  FPendingApiMsgType: TrndiAPIMsg; // emit, delivered via Synchronize.
   FHistoryFetchThread: THistoryFetchThread;
   // Shared guard: true while EITHER a TGlucoseFetchThread or
   // THistoryFetchThread is interacting with the TrndiAPI. Both backends
@@ -828,6 +845,28 @@ private
   procedure tBootFetchTimer(Sender: TObject);
   procedure tBootSpinnerTimer(Sender: TObject);
   procedure StopBootSpinner;
+  {** (Re)arm the one-shot boot-fetch timer. FormCreate arms it last; the
+      connect-failure path arms it again after the backend was replaced. }
+  procedure ArmBootFetch(const DelayMs: integer);
+  {** Runs on the main thread, from the boot worker's Synchronize, once
+      api.Connect succeeded: settles the thresholds (wizard fallback, user
+      overrides), seeds the level alerts and queues extension loading. Must
+      complete before the worker's getReadings, which stamps levels. }
+  procedure ApplyConnectedApi;
+  {** Queued by ApplyConnectResult when the boot Connect failed: error dialog,
+      Settings, then retry with the new backend or quit if nothing changed.
+      Runs after the worker has left Synchronize so a quit from the dialog
+      does not wait on a parked thread. }
+  procedure DeferredBootConnectFailure(Data: PtrInt);
+  {** Queued by ApplyConnectedApi: extension loading raises modal permission
+      prompts, which must not run while the worker is parked in Synchronize. }
+  procedure DeferredLoadExtensions(Data: PtrInt);
+  {** Drop to the "Setup" screen: no usable backend, the reading area becomes
+      a button into Settings. Safe both during FormCreate and afterwards. }
+  procedure EnterSetupScreen;
+  {** Main-thread half of APIReceiver: shows/logs the message. }
+  procedure DeliverApiMessage(const msg: string; etype: TrndiAPIMsg);
+  procedure DeliverPendingApiMessage;
   {** Disable a fired one-shot timer and drop the reference to it, without
       freeing it. Every caller runs from inside the timer's own OnTimer, where
       a free would tear down the widgetset timer whose callback is still on the

--- a/units/slicke/slicke.systemmediacontroller.pp
+++ b/units/slicke/slicke.systemmediacontroller.pp
@@ -74,6 +74,7 @@ type
     FCurrentState: TMediaState;
     FAvailablePlayers: TPlayerInfoArray;
     FIsInitialized: Boolean;
+    FLastInitAttempt: QWord; // GetTickCount64 of the last EnsureInitialized probe
     FLastTrackTitle: string;
     FVolumeStep: Integer;
 
@@ -144,6 +145,12 @@ type
 
     // Main methods
     procedure Initialize;
+    {** Initialize on first use instead of at construction: player detection
+        is one process spawn per known player (pgrep / tasklist), which is
+        not worth paying at startup for a feature that only acts on alerts.
+        A failed probe is not repeated for a minute, so a user without a
+        player does not pay it on every alert either. Returns IsInitialized. }
+    function EnsureInitialized: Boolean;
     procedure RefreshPlayerList;
 
     // Playback control
@@ -230,6 +237,7 @@ begin
   FCurrentState.IsMuted := False;
 
   FIsInitialized := False;
+  FLastInitAttempt := 0;
   FLastTrackTitle := '';
   FVolumeStep := 5;
 end;
@@ -260,6 +268,20 @@ begin
       if Assigned(FOnError) then
         FOnError(Self, 'Initialize failed: ' + E.Message);
   end;
+end;
+
+function TSystemMediaController.EnsureInitialized: Boolean;
+const
+  RETRY_INTERVAL_MS = 60000;
+begin
+  if not FIsInitialized then
+    if (FLastInitAttempt = 0) or
+      (GetTickCount64 - FLastInitAttempt >= RETRY_INTERVAL_MS) then
+    begin
+      FLastInitAttempt := GetTickCount64;
+      Initialize;
+    end;
+  Result := FIsInitialized;
 end;
 
 procedure TSystemMediaController.DetectAvailablePlayers;

--- a/units/trndi/ext/trndi.ext.engine.pp
+++ b/units/trndi/ext/trndi.ext.engine.pp
@@ -312,6 +312,13 @@ public
     {** True when the singleton already exists. Unlike @code(Instance) this
         never lazily creates the engine, so it is safe on shutdown paths. }
   class function HasInstance: boolean;
+    {** The engine when one exists and shutdown has not begun; nil otherwise.
+        Never constructs one — the guard for every caller that only wants to
+        talk to an engine that is already running (callbacks, menu items).
+        Boot no longer builds the runtime when no extension is installed, so
+        an @code(Assigned(Instance)) test there would build it as a side
+        effect of the first glucose update. }
+  class function Existing: TTrndiExtEngine;
     {** Release the singleton instance (frees resources). }
   class procedure ReleaseInstance;
 
@@ -3326,6 +3333,13 @@ end;
 class function TTrndiExtEngine.HasInstance: boolean;
 begin
   Result := FInstance <> nil;
+end;
+
+class function TTrndiExtEngine.Existing: TTrndiExtEngine;
+begin
+  if IsExtShuttingDown then
+    Exit(nil);
+  Result := FInstance;
 end;
 
 {** Release the singleton engine instance. }

--- a/units/trndi/trndi.funcs.pp
+++ b/units/trndi/trndi.funcs.pp
@@ -747,7 +747,7 @@ end;
 function callFunc(const func: string; params: array of const; out exists: boolean): string;
 begin
   result := '';
-  if not Assigned(TTrndiExtEngine.Instance) then
+  if not Assigned(TTrndiExtEngine.Existing) then
   begin  // Safe
     exists := false;
     exit;
@@ -821,7 +821,7 @@ end;
 function callFuncArrayFirst(const func: string; const firstArray: JSValueRaw; rest: array of const; out exists: boolean; autoFree: boolean; autoFreeFirst: boolean): string;
 begin
   result := '';
-  if not Assigned(TTrndiExtEngine.Instance) then
+  if not Assigned(TTrndiExtEngine.Existing) then
   begin exists := false; exit; end;
   exists := TTrndiExtEngine.Instance.FunctionExists(func);
   if not exists then
@@ -839,7 +839,7 @@ end;
 function callFuncMixed(const func: string; const raw: array of JSValueRaw; rest: array of const; out exists: boolean; restAutoFree: boolean; rawAutoFree: boolean): string;
 begin
   result := '';
-  if not Assigned(TTrndiExtEngine.Instance) then
+  if not Assigned(TTrndiExtEngine.Existing) then
   begin exists := false; exit; end;
   exists := TTrndiExtEngine.Instance.FunctionExists(func);
   if not exists then
@@ -857,7 +857,7 @@ end;
 function callFuncRaw(const func: string; const raw: array of JSValueRaw; out exists: boolean; autoFree: boolean): string;
 begin
   Result := '';
-  if not Assigned(TTrndiExtEngine.Instance) then
+  if not Assigned(TTrndiExtEngine.Existing) then
   begin exists := false; exit; end;
   exists := TTrndiExtEngine.Instance.FunctionExists(func);
   if not exists then
@@ -874,35 +874,35 @@ end;
 // Helper constructors
 function JSValueRawString(const s: RawUtf8): JSValueRaw;
 begin
-  if not Assigned(TTrndiExtEngine.Instance) then
+  if not Assigned(TTrndiExtEngine.Existing) then
     exit(JS_UNDEFINED);
   Result := TTrndiExtEngine.Instance.MakeJSString(s);
 end;
 
 function JSValueRawInt(const v: int64): JSValueRaw;
 begin
-  if not Assigned(TTrndiExtEngine.Instance) then
+  if not Assigned(TTrndiExtEngine.Existing) then
     exit(JS_UNDEFINED);
   Result := TTrndiExtEngine.Instance.MakeJSInt64(v);
 end;
 
 function JSValueRawFloat(const v: double): JSValueRaw;
 begin
-  if not Assigned(TTrndiExtEngine.Instance) then
+  if not Assigned(TTrndiExtEngine.Existing) then
     exit(JS_UNDEFINED);
   Result := TTrndiExtEngine.Instance.MakeJSFloat(v);
 end;
 
 function JSValueRawBool(const v: boolean): JSValueRaw;
 begin
-  if not Assigned(TTrndiExtEngine.Instance) then
+  if not Assigned(TTrndiExtEngine.Existing) then
     exit(JS_UNDEFINED);
   Result := TTrndiExtEngine.Instance.MakeJSBool(v);
 end;
 
 function JSValueRawArray(const values: array of const): JSValueRaw;
 begin
-  if not Assigned(TTrndiExtEngine.Instance) then
+  if not Assigned(TTrndiExtEngine.Existing) then
     exit(JS_UNDEFINED);
   Result := TTrndiExtEngine.Instance.MakeJSArray(values);
 end;

--- a/units/trndi/trndi.native.base.pp
+++ b/units/trndi/trndi.native.base.pp
@@ -323,6 +323,10 @@ class var touchOverride: TTrndiBool;
     // Theme/Env
     {** Determine if the OS/theme uses a dark appearance. Platforms override. }
   class function isDarkMode: boolean; virtual;
+    {** Forget any cached theme probe so the next @link(isDarkMode) asks the
+        desktop again. Called on resume-from-sleep; a no-op on platforms whose
+        detection is cheap enough not to cache. }
+  class procedure InvalidateThemeCache; virtual;
     {** Ask the platform to apply a dark appearance. @param(winHandle) is the
         native window handle for platforms that theme per-window (Windows
         DWM); 0 targets nothing/the app default — the same PtrUInt
@@ -1945,6 +1949,15 @@ end;
 class function TTrndiNativeBase.isDarkMode: boolean;
 begin
   Result := DefaultIsDarkMode;
+end;
+
+{------------------------------------------------------------------------------
+  InvalidateThemeCache (class, virtual)
+  -------------------------------------
+  Base: nothing is cached, so nothing to drop.
+ ------------------------------------------------------------------------------}
+class procedure TTrndiNativeBase.InvalidateThemeCache;
+begin
 end;
 
 {------------------------------------------------------------------------------

--- a/units/trndi/trndi.native.linux.pp
+++ b/units/trndi/trndi.native.linux.pp
@@ -243,6 +243,8 @@ public
     5) Fallback heuristic comparing clWindow vs clWindowText brightness.
   }
   class function isDarkMode: boolean; override;
+    {** Drops the cached @link(isDarkMode) answer so the next call re-probes. }
+  class procedure InvalidateThemeCache; override;
     {** Returns True if notify-send is available on this system. }
   class function isNotificationSystemAvailable: boolean; override;
     {** Identify notification backend: 'dbus' or 'gdbus' (the Qt6 bus paths),
@@ -527,6 +529,10 @@ end;
   the Qt tool is only a fallback, and its binary name varies by distro
   (plain `qdbus` does not exist on e.g. Fedora KDE, which ships `qdbus-qt6`).
  ------------------------------------------------------------------------------}
+var
+gGlobalMenuProbed: boolean = false;
+gGlobalMenuResult: boolean = false;
+
 class function TTrndiNativeLinux.HasGlobalMenu: boolean;
 const
   QDBUS_NAMES: array[0..4] of string =
@@ -550,14 +556,27 @@ var
       (Pos('org.kde.appmenu', lower) > 0);
   end;
 
+  // Every probe below is a subprocess with a multi-second timeout, and the
+  // answer cannot change for the lifetime of the process (the menu bar is
+  // built once from it). Startup used to pay the full chain twice.
+  function Remember(const v: boolean): boolean;
+  begin
+    gGlobalMenuResult := v;
+    gGlobalMenuProbed := true;
+    Result := v;
+  end;
+
 begin
+  if gGlobalMenuProbed then
+    Exit(gGlobalMenuResult);
+
   Result := False;
 
   toolPath := FindInPath('busctl');
   if toolPath <> '' then
     if RunAndCaptureSimpleWait(toolPath, ['--user', '--no-pager', '--acquired', 'list'],
       outS, exitCode, 7000) and (exitCode = 0) and HasRegistrar(outS) then
-      Exit(True);
+      Exit(Remember(True));
 
   toolPath := FindInPath('gdbus');
   if toolPath <> '' then
@@ -566,7 +585,7 @@ begin
       '--object-path', '/org/freedesktop/DBus',
       '--method', 'org.freedesktop.DBus.ListNames'],
       outS, exitCode, 7000) and (exitCode = 0) and HasRegistrar(outS) then
-      Exit(True);
+      Exit(Remember(True));
 
   for i := Low(QDBUS_NAMES) to High(QDBUS_NAMES) do
   begin
@@ -575,14 +594,14 @@ begin
       Continue;
     if RunAndCaptureSimpleWait(toolPath, [], outS, exitCode, 7000) and
       (exitCode = 0) and HasRegistrar(outS) then
-      Exit(True);
+      Exit(Remember(True));
   end;
 
   // GTK module hint: only match explicit appmenu-gtk module, not the generic 'appmenu' substring
   gtkMods := LowerCase(GetEnvironmentVariable('GTK_MODULES'));
   if gtkMods <> '' then
     if Pos('appmenu-gtk', gtkMods) > 0 then
-      Exit(True);
+      Exit(Remember(True));
 
   // Do NOT use KDE plasmoid presence as a global-menu indicator:
   // the plasmoid may be visible for display purposes without a desktop
@@ -591,7 +610,7 @@ begin
   // Do NOT check for appmenu helper tools on PATH; their presence does not
   // guarantee a working global menu bar integration.
 
-  Result := False;
+  Result := Remember(False);
 end;
 
 // (CurlWriteCallback_Linux moved to trndi.native.request.curl as
@@ -1126,7 +1145,45 @@ end;
   Desktop-aware detection: portal (gdbus), KDE (kreadconfig6/5), GNOME
   (gsettings), GTK_THEME, or fallback luminance heuristic.
  ------------------------------------------------------------------------------}
+var
+gDarkModeCached: boolean = false;
+gDarkModeCheckedAt: QWord = 0;
+gDarkModeValid: boolean = false;
+
+function DetectDarkModeUncached: boolean; forward;
+
 class function TTrndiNativeLinux.isDarkMode: boolean;
+const
+  // Every probe below is a bus call or a subprocess with a multi-second
+  // timeout. The value is read by every TrndiNative constructor (four of
+  // them at boot), by setColorMode on every reading and by each alert
+  // dialog, so it is cached like ShouldSuppressTrayIcon. There is no theme
+  // change signal on Linux; a switch is picked up within the TTL, which is
+  // sooner than the once-per-reading cadence that used to notice it.
+  DARK_MODE_TTL_MS = 30000;
+begin
+  if gDarkModeValid and
+    (GetTickCount64 - gDarkModeCheckedAt < DARK_MODE_TTL_MS) then
+    Exit(gDarkModeCached);
+
+  Result := DetectDarkModeUncached;
+
+  gDarkModeCached := Result;
+  gDarkModeCheckedAt := GetTickCount64;
+  gDarkModeValid := true;
+end;
+
+class procedure TTrndiNativeLinux.InvalidateThemeCache;
+begin
+  gDarkModeValid := false;
+end;
+
+{------------------------------------------------------------------------------
+  DetectDarkModeUncached
+  ----------------------
+  The actual probe chain behind isDarkMode.
+ ------------------------------------------------------------------------------}
+function DetectDarkModeUncached: boolean;
 var
   v: boolean;
   envGtkTheme: string;

--- a/units/trndi/trndi.strings.pp
+++ b/units/trndi/trndi.strings.pp
@@ -208,6 +208,7 @@ RS_SPLASH_LOADING = 'Loading Extension: ';
 RS_SPLASH_LOADING_INIT  = 'Loading Extensions...';
 
 RS_EXTFAILED = 'The following extension file returned an error while loading: %s';
+RS_EXT_NONE_LOADED = 'No extensions are loaded';
 RS_EXT_DUP_ID = 'The extension file "%s" was not loaded: apart from letter case, its name matches "%s", so both would share the same settings and permissions. Rename one of the files.';
 
 RS_INIT_TRNDI = 'Starting Trndi...';


### PR DESCRIPTION
MediaController.Initialize ran during FormCreate and probed every known
player with its own pgrep (tasklist on Windows) — twelve blocking process
spawns before the window existed, for a feature that only acts when an
alert fires. The controller now initialises on first use through
EnsureInitialized, which also retries no more than once a minute so a user
without a player does not pay the probe on every alert.

This also means a player started after Trndi is found: the boot-time
probe latched IsInitialized on whatever was running at that moment.
